### PR TITLE
ci: add running latest integration test for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           name: gradle-plugin-repo
           path: build/maven-repo/
+      - name: accept Android SDK licenses
+        run: yes | cmdline-tools/latest/bin/sdkmanager --licenses 
+        working-directory: ${ANDROID_HOME}
       - name: Run latest tests
         env:
           EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           path: build/maven-repo/
       - name: accept Android SDK licenses
         run: yes | cmdline-tools/latest/bin/sdkmanager --licenses 
-        working-directory: ${ANDROID_HOME}
+        working-directory: /usr/local/lib/android/sdk
       - name: Run latest tests
         env:
           EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: gradle-plugin-repo
+          path: build/maven-repo/
       - name: Run latest tests
         env:
           EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,20 +9,41 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    # PREP
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Setup JDK
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'zulu'
-        java-version: '17'
-        cache: gradle
-    - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
-    # BUILD
-    - name: Build environment
-      run: |
-        echo "Building ref '${{ github.ref }}'"
-    - name: Build jars
-      run: ./gradlew assemble
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          cache: gradle
+      - name: Build plugin
+        run: ./gradlew assemble publishAllPublicationsToIntreeRepository 
+      - name: Store maven repo as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: gradle-plugin-repo
+          path: build/maven-repo/
+
+  test-latest:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '20'
+          cache: gradle
+      - name: Fetch maven repo
+        uses: actions/download-artifact@v3
+        with:
+          name: gradle-plugin-repo
+      - name: Run latest tests
+        env:
+          EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}
+        working-directory: integration-test/latest
+        run: ./gradlew testWithEmulatorWtf 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,6 @@ jobs:
       - name: accept Android SDK licenses
         run: yes | cmdline-tools/latest/bin/sdkmanager --licenses 
         working-directory: /usr/local/lib/android/sdk
-      - name: print GH information
-        run: echo ref=$GITHUB_REF sha=$GITHUB_SHA head_ref=$GITHUB_HEAD_REF
       - name: Run latest tests
         env:
           EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,4 +50,31 @@ jobs:
         env:
           EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}
         working-directory: integration-test/latest
-        run: ./gradlew testWithEmulatorWtf 
+        run: ./gradlew testWithEmulatorWtf
+
+  test-oldest:
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+          cache: gradle
+      - name: Fetch maven repo
+        uses: actions/download-artifact@v3
+        with:
+          name: gradle-plugin-repo
+          path: build/maven-repo/
+      - name: accept Android SDK licenses
+        run: yes | cmdline-tools/latest/bin/sdkmanager --licenses
+        working-directory: /usr/local/lib/android/sdk
+      - name: Run latest tests
+        env:
+          EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}
+        working-directory: integration-test/oldest
+        run: ./gradlew testWithEmulatorWtf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
       - name: accept Android SDK licenses
         run: yes | cmdline-tools/latest/bin/sdkmanager --licenses 
         working-directory: /usr/local/lib/android/sdk
+      - name: print GH information
+        run: echo ref=$GITHUB_REF sha=$GITHUB_SHA head_ref=$GITHUB_HEAD_REF
       - name: Run latest tests
         env:
           EW_API_TOKEN: ${{ secrets.EW_API_TOKEN }}

--- a/.github/workflows/validate_wrapper.yml
+++ b/.github/workflows/validate_wrapper.yml
@@ -1,0 +1,16 @@
+name: validate-gradle-wrapper
+
+on:
+  pull_request:
+    paths:
+    - 'gradlew'
+    - 'gradlew.bat'
+    - 'gradle/wrapper/'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/integration-test/latest/src/androidTest/java/MinimalTests.java
+++ b/integration-test/latest/src/androidTest/java/MinimalTests.java
@@ -7,9 +7,4 @@ public class MinimalTests {
   public void junitWorks() {
     assertTrue(true);
   }
-
-  @Test
-  public void testFails() {
-    assertTrue(false);
-  }
 }

--- a/integration-test/oldest/settings.gradle
+++ b/integration-test/oldest/settings.gradle
@@ -5,7 +5,12 @@ pluginManagement {
     }
   }
 
+  def props = new Properties()
+  new File(rootDir.parentFile.parentFile, "gradle.properties").withInputStream { input ->
+    props.load(input)
+  }
+
   plugins {
-    id "wtf.emulator.gradle" version "0.10.2-SNAPSHOT"
+    id "wtf.emulator.gradle" version props.getProperty("VERSION_NAME")
   }
 }

--- a/integration-test/oldest/src/androidTest/java/MinimalTests.java
+++ b/integration-test/oldest/src/androidTest/java/MinimalTests.java
@@ -7,9 +7,4 @@ public class MinimalTests {
   public void junitWorks() {
     assertTrue(true);
   }
-
-  @Test
-  public void testFails() {
-    assertTrue(false);
-  }
 }


### PR DESCRIPTION
Runs the `oldest` (min supported versions) and `latest` (max supported versions) integration tests for every PR build.