### PR TITLE
fix: don't add repo if dependencyManagement is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,6 @@ The plugin is compatible with any working combination of these ranges:
 |-----------------------|--------|---------------|
 | JDK                   | 11     | 20            |
 | Gradle                | 6.6.1  | 8.1.1         |
-| Android Gradle Plugin | 4.0.0  | 8.2.0-alpha01 |
+| Android Gradle Plugin | 4.0.0  | 8.2.0-alpha04 |
 
-NOTE: for any pre-release version families (`alpha`, `beta`, `rc`) only the latest version
-from the family is supported.
+NOTE: only the latest of any prerelase versions (`alpha`, `beta`, `rc`) is supported.

--- a/integration-test/latest/build.gradle
+++ b/integration-test/latest/build.gradle
@@ -4,17 +4,12 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:8.2.0-alpha01'
+    classpath 'com.android.tools.build:gradle:8.2.0-alpha04'
   }
 }
 
 plugins {
   id "wtf.emulator.gradle"
-}
-
-repositories {
-  google()
-  mavenCentral()
 }
 
 apply plugin: 'com.android.application'

--- a/integration-test/latest/settings.gradle
+++ b/integration-test/latest/settings.gradle
@@ -9,3 +9,14 @@ pluginManagement {
     id "wtf.emulator.gradle" version "+"
   }
 }
+
+dependencyResolutionManagement {
+  repositories {
+    google()
+    mavenCentral()
+    maven {
+      url "https://maven.emulator.wtf/releases/"
+      content { includeGroup("wtf.emulator") }
+    }
+  }
+}

--- a/src/main/java/wtf/emulator/EwPlugin.java
+++ b/src/main/java/wtf/emulator/EwPlugin.java
@@ -116,6 +116,10 @@ public class EwPlugin implements Plugin<Project> {
   }
 
   private static void configureRepository(Project target, EwExtension ext) {
+    if (!EwProperties.ADD_REPOSITORY.getFlag(target, true)) {
+      return;
+    }
+
     Semver gradleVersion = new Semver(target.getGradle().getGradleVersion(), Semver.SemverType.LOOSE);
     if (gradleVersion.isGreaterThanOrEqualTo(new Semver("6.8", Semver.SemverType.LOOSE))) {
       // TODO(madis) yuck
@@ -133,7 +137,8 @@ public class EwPlugin implements Plugin<Project> {
       }
 
       RepositoriesMode mode = settings.getDependencyResolutionManagement().getRepositoriesMode().getOrNull();
-      if (mode == null || RepositoriesMode.PREFER_PROJECT.equals(mode)) {
+      int settingsRepoCount = settings.getDependencyResolutionManagement().getRepositories().size();
+      if ((mode == null || mode == RepositoriesMode.PREFER_PROJECT) && settingsRepoCount == 0) {
         registerMavenRepo(target);
       } else {
         // ping user after project evaluate to allow suppressing this check in dsl

--- a/src/main/java/wtf/emulator/EwPlugin.java
+++ b/src/main/java/wtf/emulator/EwPlugin.java
@@ -170,6 +170,7 @@ public class EwPlugin implements Plugin<Project> {
     target.getRepositories().maven(repo -> {
       try {
         repo.setUrl(new URI(MAVEN_URL).toURL());
+        repo.mavenContent((desc) -> desc.includeGroup("wtf.emulator"));
       } catch (MalformedURLException | URISyntaxException e) {
         throw new IllegalStateException(e);
       }

--- a/src/main/java/wtf/emulator/EwProperties.java
+++ b/src/main/java/wtf/emulator/EwProperties.java
@@ -1,0 +1,23 @@
+package wtf.emulator;
+
+import org.gradle.api.Project;
+
+public enum EwProperties {
+  ADD_REPOSITORY("addrepository");
+
+  private static final String PREFIX = "wtf.emulator";
+
+  private final String propName;
+
+  EwProperties(String propName) {
+    this.propName = propName;
+  }
+
+  public boolean getFlag(Project project, boolean defaultValue) {
+    Object value = project.findProperty(PREFIX + "." + propName);
+    if (value == null) {
+      return defaultValue;
+    }
+    return Boolean.parseBoolean(value.toString());
+  }
+}


### PR DESCRIPTION
- use settings.gradle for defining repos in `integration-test/latest`
- don't add our maven repo if there are _any_ repos defined in `dependencyManagement`
- if we do end up adding our repo then limit artifact resolution to the `wtf.emulator` group
- bumped AGP to 8.2.0-alpha04 in `integration-test/latest`