### PR TITLE
feat: add http proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The `emulatorwtf` plugin DSL supports the following configuration options:
 
 ```groovy
 emulatorwtf {
-  // CLI version to use, defaults to 0.9.14
-  version = '0.9.14'
+  // CLI version to use, defaults to 0.9.15
+  version = '0.9.15'
 
   // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
   // instead of this or passing this value in via a project property
@@ -209,6 +209,16 @@ emulatorwtf {
       enabled = false
     }
   }
+
+  // Configure a HTTP proxy to use when making requests to emulator.wtf API
+  // these values default to standard JVM system properties `http.proxyHost`,
+  // `http.proxyPort`, `http.proxyUser` and `http.proxyPassword` - there's no need to specify
+  // them if your Gradle daemon has these props set.
+  // NOTE: this is for setting up the test, it has no effect on your tests in the emulator
+  proxyHost = "localhost"
+  proxyPort = 8080
+  proxyUser = "user"
+  proxyPassword = "hunter2"
 }
 ```
 

--- a/src/main/java/wtf/emulator/EwExecTask.java
+++ b/src/main/java/wtf/emulator/EwExecTask.java
@@ -163,6 +163,22 @@ public abstract class EwExecTask extends DefaultTask {
   @Input
   public abstract Property<String> getTestTargets();
 
+  @Optional
+  @Input
+  public abstract Property<String> getProxyHost();
+
+  @Optional
+  @Input
+  public abstract Property<Integer> getProxyPort();
+
+  @Optional
+  @Input
+  public abstract Property<String> getProxyUser();
+
+  @Optional
+  @Input
+  public abstract Property<String> getProxyPassword();
+
   @TaskAction
   public void runTests() {
     WorkQueue workQueue = getWorkerExecutor().noIsolation();
@@ -200,6 +216,10 @@ public abstract class EwExecTask extends DefaultTask {
       p.getAsync().set(getAsync());
       p.getPrintOutput().set(getPrintOutput());
       p.getTestTargets().set(getTestTargets());
+      p.getProxyHost().set(getProxyHost());
+      p.getProxyPort().set(getProxyPort());
+      p.getProxyUser().set(getProxyUser());
+      p.getProxyPassword().set(getProxyPassword());
     });
   }
 }

--- a/src/main/java/wtf/emulator/EwInvokeConfiguration.java
+++ b/src/main/java/wtf/emulator/EwInvokeConfiguration.java
@@ -47,4 +47,12 @@ public interface EwInvokeConfiguration {
   Property<Boolean> getPrintOutput();
 
   Property<String> getTestTargets();
+
+  Property<String> getProxyHost();
+
+  Property<Integer> getProxyPort();
+
+  Property<String> getProxyUser();
+
+  Property<String> getProxyPassword();
 }

--- a/src/main/java/wtf/emulator/EwPlugin.java
+++ b/src/main/java/wtf/emulator/EwPlugin.java
@@ -364,6 +364,11 @@ public class EwPlugin implements Plugin<Project> {
 
       task.getTestTargets().set(ext.getTestTargets());
 
+      task.getProxyHost().set(ext.getProxyHost());
+      task.getProxyPort().set(ext.getProxyPort());
+      task.getProxyUser().set(ext.getProxyUser());
+      task.getProxyPassword().set(ext.getProxyPassword());
+
       additionalConfigure.accept(task);
     });
 

--- a/src/main/java/wtf/emulator/EwWorkAction.java
+++ b/src/main/java/wtf/emulator/EwWorkAction.java
@@ -174,6 +174,19 @@ public abstract class EwWorkAction implements WorkAction<EwWorkParameters> {
           spec.args("--test-targets", getParameters().getTestTargets().get());
         }
 
+        if (getParameters().getProxyHost().isPresent()) {
+          spec.args("--proxy-host", getParameters().getProxyHost().get());
+        }
+        if (getParameters().getProxyPort().isPresent()) {
+          spec.args("--proxy-port", getParameters().getProxyPort().get().toString());
+        }
+        if (getParameters().getProxyUser().isPresent()) {
+          spec.args("--proxy-user", getParameters().getProxyUser().get());
+        }
+        if (getParameters().getProxyPassword().isPresent()) {
+          spec.args("--proxy-password", getParameters().getProxyPassword().get());
+        }
+
         spec.args("--json");
 
         if (getParameters().getPrintOutput().getOrElse(false)) {


### PR DESCRIPTION
- bump `ew-cli` to 0.9.15 (adds proxy support)
- add `proxy*` options to the extension, task and work action
- default the `proxy*` options to `http.proxy*` sys props when present 