### PR TITLE
feat: bump ew-cli, add shard target runtime and flaky repeat opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The `emulatorwtf` plugin DSL supports the following configuration options:
 
 ```groovy
 emulatorwtf {
-  // CLI version to use, defaults to 0.9.16
-  version = '0.9.16'
+  // CLI version to use, defaults to 0.9.17
+  version = '0.9.17'
 
   // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
   // instead of this or passing this value in via a project property
@@ -119,11 +119,11 @@ emulatorwtf {
   // record a video of the test run
   recordVideo = true
 
-  // ignore test failures and keep running the build
+  // ignore test failures and keep running the build, defaults to false
   //
   // NOTE: the build outcome _will_ be success at the end, use the JUnit XML files to
   //       check for test failures
-  ignoreFailures = true
+  ignoreFailures = false
 
   // devices to test on, Defaults to [[model: 'Pixel2', version: 27]]
   devices = [
@@ -160,6 +160,13 @@ emulatorwtf {
   // for instance to only run medium tests:
   environmentVariables = [size: 'medium']
 
+  // Set to the a minutes value to split your tests into multiple shards
+  // dynamically, the number of shards will be figured out based on historical
+  // test times. This is a good way to ensure a consistent runtime as your
+  // testsuite grows or shrinks - we will adjust the number of shards as
+  // needed
+  shardTargetRuntime = 2
+
   // Set to a number larger than 1 to randomly split your tests into multiple
   // shards to be executed in parallel
   numUniformShards = 3
@@ -175,6 +182,10 @@ emulatorwtf {
   // Set to a non-zero value to repeat device/shards that failed, the repeat
   // attempts will be executed in parallel
   numFlakyTestAttempts = 3
+
+  // Whether to reattempt full shards (all) or only failed tests (failed_only)
+  // in case of test failures. Defaults to failed_only.
+  flakyTestRepeatMode = failed_only
 
   // Directories to pull from device after test is over, will be stored in
   // baseOutputDir/${variant}:

--- a/src/main/java/wtf/emulator/EwExecTask.java
+++ b/src/main/java/wtf/emulator/EwExecTask.java
@@ -100,6 +100,10 @@ public abstract class EwExecTask extends DefaultTask {
 
   @Optional
   @Input
+  public abstract Property<Integer> getShardTargetRuntime();
+
+  @Optional
+  @Input
   public abstract ListProperty<String> getDirectoriesToPull();
 
   @Optional
@@ -125,6 +129,10 @@ public abstract class EwExecTask extends DefaultTask {
   @Optional
   @Input
   public abstract Property<Integer> getNumFlakyTestAttempts();
+
+  @Optional
+  @Input
+  public abstract Property<String> getFlakyTestRepeatMode();
 
   @Optional
   @Input
@@ -200,6 +208,7 @@ public abstract class EwExecTask extends DefaultTask {
       p.getNumUniformShards().set(getNumUniformShards());
       p.getNumBalancedShards().set(getNumBalancedShards());
       p.getNumShards().set(getNumShards());
+      p.getShardTargetRuntime().set(getShardTargetRuntime());
       p.getDirectoriesToPull().set(getDirectoriesToPull());
       p.getSideEffects().set(getSideEffects());
       p.getTimeout().set(getTestTimeout());
@@ -207,6 +216,7 @@ public abstract class EwExecTask extends DefaultTask {
       p.getFileCacheTtl().set(getFileCacheTtl());
       p.getTestCacheEnabled().set(getTestCacheEnabled());
       p.getNumFlakyTestAttempts().set(getNumFlakyTestAttempts());
+      p.getFlakyTestRepeatMode().set(getFlakyTestRepeatMode());
       p.getDisplayName().set(getDisplayName());
       p.getScmUrl().set(getScmUrl());
       p.getScmCommitHash().set(getScmCommitHash());

--- a/src/main/java/wtf/emulator/EwExtension.java
+++ b/src/main/java/wtf/emulator/EwExtension.java
@@ -35,7 +35,7 @@ public abstract class EwExtension implements EwInvokeConfiguration {
 
   @Inject
   public EwExtension(ObjectFactory objectFactory) {
-    getVersion().convention("0.9.16");
+    getVersion().convention("0.9.17");
     getSideEffects().convention(false);
     getOutputs().convention(Collections.emptyList());
 

--- a/src/main/java/wtf/emulator/EwInvokeConfiguration.java
+++ b/src/main/java/wtf/emulator/EwInvokeConfiguration.java
@@ -19,6 +19,7 @@ public interface EwInvokeConfiguration {
   Property<Integer> getNumUniformShards();
   Property<Integer> getNumShards();
   Property<Integer> getNumBalancedShards();
+  Property<Integer> getShardTargetRuntime();
 
   ListProperty<String> getDirectoriesToPull();
 
@@ -33,6 +34,8 @@ public interface EwInvokeConfiguration {
   Property<Boolean> getTestCacheEnabled();
 
   Property<Integer> getNumFlakyTestAttempts();
+
+  Property<String> getFlakyTestRepeatMode();
 
   Property<String> getDisplayName();
 

--- a/src/main/java/wtf/emulator/EwPlugin.java
+++ b/src/main/java/wtf/emulator/EwPlugin.java
@@ -332,6 +332,8 @@ public class EwPlugin implements Plugin<Project> {
       task.getNumUniformShards().set(ext.getNumUniformShards());
       task.getNumShards().set(ext.getNumShards());
       task.getNumBalancedShards().set(ext.getNumBalancedShards());
+      task.getShardTargetRuntime().set(ext.getShardTargetRuntime());
+
       task.getDirectoriesToPull().set(ext.getDirectoriesToPull());
 
       task.getTestTimeout().set(ext.getTimeout());
@@ -342,6 +344,7 @@ public class EwPlugin implements Plugin<Project> {
       task.getTestCacheEnabled().set(ext.getTestCacheEnabled());
 
       task.getNumFlakyTestAttempts().set(ext.getNumFlakyTestAttempts());
+      task.getFlakyTestRepeatMode().set(ext.getFlakyTestRepeatMode());
 
       task.getScmUrl().set(ext.getScmUrl());
       task.getScmCommitHash().set(ext.getScmCommitHash());

--- a/src/main/java/wtf/emulator/EwWorkAction.java
+++ b/src/main/java/wtf/emulator/EwWorkAction.java
@@ -133,7 +133,9 @@ public abstract class EwWorkAction implements WorkAction<EwWorkParameters> {
           }
         }
 
-        if (getParameters().getNumBalancedShards().isPresent()) {
+        if (getParameters().getShardTargetRuntime().isPresent()) {
+          spec.args("--shard-target-runtime", getParameters().getShardTargetRuntime().get() + "m");
+        } else if (getParameters().getNumBalancedShards().isPresent()) {
           spec.args("--num-balanced-shards", String.valueOf(getParameters().getNumBalancedShards().get()));
         } else if (getParameters().getNumUniformShards().isPresent()) {
           spec.args("--num-uniform-shards", String.valueOf(getParameters().getNumUniformShards().get()));
@@ -164,6 +166,10 @@ public abstract class EwWorkAction implements WorkAction<EwWorkParameters> {
 
         if (getParameters().getNumFlakyTestAttempts().isPresent()) {
           spec.args("--num-flaky-test-attempts", getParameters().getNumFlakyTestAttempts().get().toString());
+        }
+
+        if (getParameters().getFlakyTestRepeatMode().isPresent()) {
+          spec.args("--flaky-test-repeat-mode", getParameters().getFlakyTestRepeatMode().get());
         }
 
         if (getParameters().getAsync().getOrElse(false)) {


### PR DESCRIPTION
- bump `ew-cli` to `0.0.17`
- add `shardTargetRuntime` and `flakyTestRepeatMode` options, forwarded to cli as `--shard-target-runtime` and `--flaky-test-repeat-mode` respectively