### PR TITLE
Wipe output directory before running tests

### DIFF
--- a/src/main/java/wtf/emulator/exec/EwWorkAction.java
+++ b/src/main/java/wtf/emulator/exec/EwWorkAction.java
@@ -1,9 +1,8 @@
 package wtf.emulator.exec;
 
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.process.ExecOperations;
 import org.gradle.workers.WorkAction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 
@@ -11,11 +10,17 @@ public abstract class EwWorkAction implements WorkAction<EwWorkParameters> {
   @Inject
   public abstract ExecOperations getExecOperations();
 
-  private final Logger log = LoggerFactory.getLogger("emulator.wtf");
+  @Inject
+  public abstract FileSystemOperations getFileSystemOperations();
 
   @Override
   public void execute() {
+    EwWorkParameters parameters = getParameters();
+    if (parameters.getOutputsDir().isPresent()) {
+      getFileSystemOperations().delete((spec) -> spec.delete(parameters.getOutputsDir()));
+    }
+
     EwCliExecutor cliExecutor = new EwCliExecutor(getExecOperations());
-    cliExecutor.invokeCli(getParameters());
+    cliExecutor.invokeCli(parameters);
   }
 }


### PR DESCRIPTION
If the outputs directory is non-empty when a test task runs it ends up containing a mixture of old and new results. This generally doesn't matter on ephemeral CI machines, but it does if you run tests on emulator.wtf from your local machine (particularly when you're running more fine-grained test targets).