### PR TITLE
fix: don't capture AndroidVariant when serializing providers for config cache

### DIFF
--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/VariantConfigurator.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/VariantConfigurator.java
@@ -94,10 +94,11 @@ public class VariantConfigurator {
       // look up the referenced target variant
       // TODO(madis) use artifact apis here instead?
       Configuration testedApks = target.getConfigurations().maybeCreate(variant.getName() + "TestedApks");
+      final String variantName = variant.getName();
       task.getApks().set(
         testedApks.getIncoming().artifactView(view -> {
           view.getAttributes().attribute(VariantAttr.ATTRIBUTE,
-            target.getObjects().named(VariantAttr.class, variant.getName()));
+            target.getObjects().named(VariantAttr.class, variantName));
           view.getAttributes().attribute(compat.getArtifactTypeAttribute(), "apk");
         }).getFiles()
       );

--- a/integration-test/project-isolation/gradle.properties
+++ b/integration-test/project-isolation/gradle.properties
@@ -1,3 +1,3 @@
 android.useAndroidX=true
-#org.gradle.unsafe.isolated-projects=true
-#org.gradle.configuration-cache=true
+org.gradle.unsafe.isolated-projects=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
Capture specific primitives (e.g. `variantName` instead of `variant.name`) to make sure we don't accidentally try to serialize all of `AndroidVariant` when running with config cache.

Technically this means that we might drop some changes to something like instrumentation args if some other non-AGP plugin mutates them after we've configured our plugin but I don't think that's really a huge problem, at least today.

Fixes #18.