### PR TITLE
feat: disable test task cache when test cache is disabled

### DIFF
--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
@@ -175,6 +175,10 @@ public class TaskConfigurator {
     task.getFileCacheTtl().set(ext.getFileCacheTtl());
 
     task.getTestCacheEnabled().set(ext.getTestCacheEnabled());
+    if (ext.getTestCacheEnabled().isPresent() && !ext.getTestCacheEnabled().get()) {
+      // if test cache is disabled, always rerun the task
+      task.getOutputs().upToDateWhen(it -> false);
+    }
 
     task.getNumFlakyTestAttempts().set(ext.getNumFlakyTestAttempts());
     task.getFlakyTestRepeatMode().set(ext.getFlakyTestRepeatMode());


### PR DESCRIPTION
Always re-run test tasks if the test cache was disabled in the extension dsl by the user.