### PR TITLE
feat!: add typesafe device spec apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,17 @@ emulatorwtf {
   //       check for test failures
   ignoreFailures = false
 
-  // devices to test on, Defaults to [[model: 'Pixel2', version: 27]]
-  devices = [
-    [model: 'NexusLowRes', version: 30, atd: true],
-    [model: 'Pixel2', version: 23]
-  ]
+  // devices to test on, Defaults to Pixel7, version 30, gpu auto
+  device {
+    model = EwDeviceModel.Pixel7
+    version = 30
+    gpu = EwGpuMode.auto
+  }
+  device {
+    model = EwDeviceModel.NexusLowRes
+    version = 21
+    gpu = EwGpuMode.software
+  }
 
   // Set the test timeout, defaults to 15 minutes
   timeout = Duration.ofHours(1)

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EmulatorWtfException.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EmulatorWtfException.java
@@ -2,6 +2,10 @@ package wtf.emulator;
 
 import org.gradle.api.GradleException;
 
+/**
+ * Thrown when ew-cli execution fails. This does not necessary indicate an error,
+ * it can also be thrown when there are failing tests.
+ */
 public class EmulatorWtfException extends GradleException {
   public EmulatorWtfException() {
     super();

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwDeviceModel.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwDeviceModel.java
@@ -1,0 +1,26 @@
+package wtf.emulator;
+
+/**
+ * Device model (screen size, density) to use for executing tests.
+ */
+public enum EwDeviceModel {
+  PIXEL_2("Pixel2"),
+  PIXEL_2_ATD("Pixel2Atd"),
+  PIXEL_7("Pixel7"),
+  PIXEL_7_ATD("Pixel7Atd"),
+  TABLET_10("Tablet10"),
+  TABLET_10_ATD("Tablet10Atd"),
+  NEXUS_LOW_RES("NexusLowRes"),
+  NEXUS_LOW_RES_ATD("NexusLowResAtd"),
+  MONITOR("Monitor");
+
+  private final String cliValue;
+
+  EwDeviceModel(String cliValue) {
+    this.cliValue = cliValue;
+  }
+
+  public String getCliValue() {
+    return cliValue;
+  }
+}

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwDeviceSpec.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwDeviceSpec.java
@@ -1,0 +1,53 @@
+package wtf.emulator;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Specific device configuration to run tests on.
+ */
+public class EwDeviceSpec implements Serializable {
+  private final EwDeviceModel model;
+  private final int version;
+  private final EwGpuMode gpu;
+
+  public static EwDeviceSpecBuilder builder() {
+    return new EwDeviceSpecBuilder();
+  }
+
+  public EwDeviceSpec(EwDeviceModel model, int version, EwGpuMode gpu) {
+    this.model = model;
+    this.version = version;
+    this.gpu = gpu;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    EwDeviceSpec that = (EwDeviceSpec) o;
+    return version == that.version && model == that.model && gpu == that.gpu;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(model, version, gpu);
+  }
+
+  public Map<String, String> toCliMap() {
+    return Map.of(
+        "model", model.getCliValue(),
+        "version", Integer.toString(version),
+        "gpu", gpu.getCliValue()
+    );
+  }
+
+  public EwDeviceSpecBuilder toBuilder() {
+    return builder().model(model).version(version).gpu(gpu);
+  }
+}

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwDeviceSpecBuilder.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwDeviceSpecBuilder.java
@@ -1,0 +1,45 @@
+package wtf.emulator;
+
+/**
+ * Specific device configuration to run tests on.
+ */
+public class EwDeviceSpecBuilder {
+  private EwDeviceModel model = EwDeviceModel.PIXEL_7;
+  private int version = 30;
+  private EwGpuMode gpu = EwGpuMode.AUTO;
+
+  /**
+   * Sets the device model to use, see {@link EwDeviceModel} or
+   * <a href="https://docs.emulator.wtf/emulators/">https://docs.emulator.wtf/emulators/</a> for available values.
+   */
+  public EwDeviceSpecBuilder model(EwDeviceModel model) {
+    this.model = model;
+    return this;
+  }
+
+  /**
+   * Sets the Android API level to use. Use {@code ew-cli --models} or see
+   * <a href="https://docs.emulator.wtf/emulators/">https://docs.emulator.wtf/emulators/</a> for available
+   * model x version combinations.
+   */
+  public EwDeviceSpecBuilder version(int apiLevel) {
+    this.version = apiLevel;
+    return this;
+  }
+
+  /**
+   * Sets the GPU mode to use. NOTE: when using {@link EwGpuMode#AUTO} there's no guarantee that the emulator will
+   * actually use GPU acceleration in rare cases.
+   *
+   * @param gpuMode either {@link EwGpuMode#SOFTWARE} or {@link EwGpuMode#AUTO} (default).
+   * @return
+   */
+  public EwDeviceSpecBuilder gpu(EwGpuMode gpuMode) {
+    this.gpu = gpuMode;
+    return this;
+  }
+
+  public EwDeviceSpec build() {
+    return new EwDeviceSpec(model, version, gpu);
+  }
+}

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwExtension.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwExtension.java
@@ -1,6 +1,8 @@
 package wtf.emulator;
 
 import org.gradle.api.Action;
+import org.gradle.api.DomainObjectCollection;
+import org.gradle.api.DomainObjectSet;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
@@ -27,11 +29,11 @@ public abstract class EwExtension implements EwInvokeConfiguration {
 
   public abstract DirectoryProperty getBaseOutputDir();
 
-  public abstract ListProperty<Map<String, Object>> getDevices();
-
   public abstract MapProperty<String, Object> getEnvironmentVariables();
 
   private Action<EwVariantFilter> filter = null;
+
+  private final DomainObjectSet<EwDeviceSpec> devices;
 
   @Inject
   public EwExtension(ObjectFactory objectFactory) {
@@ -46,11 +48,23 @@ public abstract class EwExtension implements EwInvokeConfiguration {
     sysPropConvention(getProxyPassword(), "https.proxyPassword", "http.proxyPassword");
 
     this.variantCount = objectFactory.property(Integer.class).convention(0);
+
+    this.devices = objectFactory.domainObjectSet(EwDeviceSpec.class);
   }
 
   @SuppressWarnings("unused")
   public void variantFilter(Action<EwVariantFilter> filter) {
     this.filter = filter;
+  }
+
+  public DomainObjectCollection<EwDeviceSpec> getDevices() {
+    return this.devices;
+  }
+
+  public void device(Action<EwDeviceSpecBuilder> action) {
+    EwDeviceSpecBuilder builder = new EwDeviceSpecBuilder();
+    action.execute(builder);
+    this.devices.add(builder.build());
   }
 
   protected Action<EwVariantFilter> getFilter() {

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwGpuMode.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwGpuMode.java
@@ -1,0 +1,26 @@
+package wtf.emulator;
+
+public enum EwGpuMode {
+  /**
+   * Use software rendering. Use this if you need deterministic pixel-perfect rendering, e.g. for
+   * screenshot testing.
+   */
+  SOFTWARE("software"),
+
+  /**
+   * Use hardware rendering if available. Typically this is available, but there may
+   * be rare cases where no machines with GPU acceleration are available in our workload cluster.
+   * In such cases, the emulator may still use software rendering.
+   */
+  AUTO("auto");
+
+  private final String cliValue;
+
+  EwGpuMode(String cliValue) {
+    this.cliValue = cliValue;
+  }
+
+  public String getCliValue() {
+    return cliValue;
+  }
+}

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwInvokeConfiguration.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwInvokeConfiguration.java
@@ -7,59 +7,201 @@ import org.gradle.api.provider.Property;
 import java.time.Duration;
 
 public interface EwInvokeConfiguration {
+  /**
+   * Specify the list of various output types (e.g. {@link OutputType#LOGCAT}, {@link OutputType#MERGED_RESULTS_XML}, etc)
+   * to download after the test has finished.
+   */
   ListProperty<OutputType> getOutputs();
+
+  /**
+   * Whether to record video of the test run. Defaults to true.
+   */
   Property<Boolean> getRecordVideo();
 
+  /**
+   * Whether to use the orchestrator test runner.
+   * See more about orchestrator <a href="https://developer.android.com/training/testing/instrumented-tests/androidx-test-libraries/runner#use-android">here</a>
+   */
   Property<Boolean> getUseOrchestrator();
+
+  /**
+   * Set to true to clear app data (shared prefs, databases, files) before each test run.
+   * Requires {@link #getUseOrchestrator()} to be set to true.
+   */
   Property<Boolean> getClearPackageData();
+
+  /**
+   * Set to true to fetch coverage data from the emulator after the test run has finished.
+   */
   Property<Boolean> getWithCoverage();
 
+  /**
+   * Specify the list of additional APKs to install before running the tests, for
+   * more complex multi-app end-to-end tests.
+   */
   Property<FileCollection> getAdditionalApks();
 
+  /**
+   * Use {@code AndroidJUnitRunner}'s {@code numShards} and {@code shardIndex} environment variables to spread
+   * tests roughly uniformly across shards.
+   * Not recommended for use, prefer {@link #getShardTargetRuntime()} or {@link #getNumBalancedShards()} instead.
+   * Read more about uniform sharding <a href="https://docs.emulator.wtf/concepts/sharding/#uniform-sharding">here</a>.
+   */
   Property<Integer> getNumUniformShards();
+
+  /**
+   * Evenly splits tests to shards based on the counts. For example with a test suite of 40 tests and 4 shards, each
+   * shard will use exactly 10 tests.
+   * Read more about even sharding <a href="https://docs.emulator.wtf/concepts/sharding/#even-sharding">here</a>.
+   */
   Property<Integer> getNumShards();
+
+  /**
+   * Split tests to shards based on the runtime of each test, with the goal of making each shard run for roughly the
+   * same amount of time.
+   * Read more about balanced sharding <a href="https://docs.emulator.wtf/concepts/sharding/#balanced-sharding">here</a>.
+   */
   Property<Integer> getNumBalancedShards();
+
+  /**
+   * Set the target runtime for each shard in seconds. This will be used to calculate the number of shards to use.
+   * The most hands-off approach to sharding - just set the target runtime and let emulator.wtf do the rest.
+   * Read more about targeted runtime sharding <a href="https://docs.emulator.wtf/concepts/sharding/#targeted-runtime-sharding">here</a>.
+   */
   Property<Integer> getShardTargetRuntime();
 
+  /**
+   * Set the list of directories to pull from the emulator after the test run has finished.
+   * NOTE: make sure to include {@link OutputType#PULLED_DIRS} in {@link #getOutputs()} to download the pulled directories
+   * if needed.
+   */
   ListProperty<String> getDirectoriesToPull();
 
+  /**
+   * Indicates that the test run has side effects, i.e. it hits external resources and might be a part of a bigger test
+   * suite. Adding this flag means that the test will not be automatically retried in case of errors and any Gradle
+   * caching for the test tasks will be disabled.
+   */
   Property<Boolean> getSideEffects();
 
+  /**
+   * Fail if the test runtime exceeds the given timeout value.
+   */
   Property<Duration> getTimeout();
 
+  /**
+   * Enable-disable the file cache for the test run. The file cache will store the input test files (apks) so repeated
+   * test runs with the same input apks can skip uploading them. You can control how long the files are stored in the
+   * cache with the {@link #getFileCacheTtl()} property.
+   */
   Property<Boolean> getFileCacheEnabled();
 
+  /**
+   * Set the time-to-live for the files stored in the file cache. The files will be deleted after the given duration.
+   * Only relevant if {@link #getFileCacheEnabled()} is set to true.
+   */
   Property<Duration> getFileCacheTtl();
 
+  /**
+   * Enable-disable the test cache for the test run. The test cache will store the test results so repeated test runs
+   * with the same input apks and configuration can skip running the tests.
+   */
   Property<Boolean> getTestCacheEnabled();
 
+  /**
+   * Add repeat attempts of devices and/or shards where there were test failures. Maximum number of flaky test attempts
+   * is 10. The test attempts will be started in parallel, e.g. with number of flaky test attempts of 3 an extra three
+   * attempts will be started in case of a test failure.
+   */
   Property<Integer> getNumFlakyTestAttempts();
 
-  Property<String> getFlakyTestRepeatMode();
+  /**
+   * Whether to repeat the whole failed shard ({@link FlakyRepeatMode#ALL}) or only the failed tests
+   * ({@link FlakyRepeatMode#FAILED_ONLY}) in case of flaky tests.
+   * The default mode is {@link FlakyRepeatMode#FAILED_ONLY}.
+   */
+  Property<FlakyRepeatMode> getFlakyTestRepeatMode();
 
+  /**
+   * Display name of the test run in the emulator.wtf web app results UI.
+   */
   Property<String> getDisplayName();
 
+  /**
+   * Explicitly set the URL of the source control management system where the test run was triggered from.
+   * If not set this will be guessed based on working directory git information.
+   */
   Property<String> getScmUrl();
 
+  /**
+   * Explicitly set the commit hash of the source control management system where the test run was triggered from.
+   * If not set this will be guessed based on working directory git information.
+   */
   Property<String> getScmCommitHash();
 
+  /**
+   * Explicitly set the branch name of the source control management system where the test run was triggered from.
+   * If not set this will be guessed based on working directory git information.
+   */
   Property<String> getScmRefName();
 
+  /**
+   * Explicitly set the pull request URL of the source control management system where the test run was triggered from.
+   * If not set this will be guessed based on working directory git information.
+   */
   Property<String> getScmPrUrl();
 
+  /**
+   * Set to true to not fail the tasks/build if tests are failing.
+   * The tasks will still fail if any other error occurs (timeouts, emulator.wtf failures, etc).
+   */
   Property<Boolean> getIgnoreFailures();
 
+  /**
+   * Run the test asynchronously, without waiting for the results. This shines when used together with our
+   * <a href="https://docs.emulator.wtf/github/commit-statuses/">GitHub integration</a>.
+   */
   Property<Boolean> getAsync();
 
+  /**
+   * Set to true to print any {@code ew-cli} raw output to the console while running the tests.
+   */
   Property<Boolean> getPrintOutput();
 
+  /**
+   * Run only a subset of matching test targets, these will be forwarded to {@code AndroidJUnitRunner}.
+   * See the full list of configuration options
+   * <a href="https://developer.android.com/reference/androidx/test/runner/AndroidJUnitRunner#typical-usage">here</a>.
+   * Some examples:
+   * run all tests in a class: {@code class com.example.Foo}
+   * run a single test called bar: {@code class com.example.Foo#bar}
+   * run all tests in a package: {@code package com.example}
+   * run all tests annotated with {@code @MediumTest}: {@code size medium}
+   * run all tests in a package annotated with {@code @MediumTest}: {@code size medium package com.example}
+   */
   Property<String> getTestTargets();
 
+  /**
+   * Explicitly set the proxy host to use for communicating with emulator.wtf backend.
+   * By default the Java system properties are used for discovering proxy settings.
+   */
   Property<String> getProxyHost();
 
+  /**
+   * Explicitly set the proxy port to use for communicating with emulator.wtf backend.
+   * By default the Java system properties are used for discovering proxy settings.
+   */
   Property<Integer> getProxyPort();
 
+  /**
+   * Explicitly set the proxy username to use for communicating with emulator.wtf backend.
+   * By default the Java system properties are used for discovering proxy settings.
+   */
   Property<String> getProxyUser();
 
+  /**
+   * Explicitly set the proxy password to use for communicating with emulator.wtf backend.
+   * By default the Java system properties are used for discovering proxy settings.
+   */
   Property<String> getProxyPassword();
 }

--- a/gradle-plugin-api/src/main/java/wtf/emulator/FlakyRepeatMode.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/FlakyRepeatMode.java
@@ -1,0 +1,16 @@
+package wtf.emulator;
+
+public enum FlakyRepeatMode {
+  ALL("all"),
+  FAILED_ONLY("failed_only");
+
+  private final String cliValue;
+
+  FlakyRepeatMode(String cliValue) {
+    this.cliValue = cliValue;
+  }
+
+  public String getCliValue() {
+    return cliValue;
+  }
+}

--- a/gradle-plugin-core/src/main/java/wtf/emulator/EwExecTask.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/EwExecTask.java
@@ -138,7 +138,7 @@ public abstract class EwExecTask extends DefaultTask {
 
   @Optional
   @Input
-  public abstract Property<String> getFlakyTestRepeatMode();
+  public abstract Property<FlakyRepeatMode> getFlakyTestRepeatMode();
 
   @Optional
   @Input

--- a/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCliExecutor.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCliExecutor.java
@@ -342,7 +342,7 @@ public class EwCliExecutor {
     }
 
     if (parameters.getFlakyTestRepeatMode().isPresent()) {
-      spec.args("--flaky-test-repeat-mode", parameters.getFlakyTestRepeatMode().get());
+      spec.args("--flaky-test-repeat-mode", parameters.getFlakyTestRepeatMode().get().getCliValue());
     }
 
     if (parameters.getAsync().getOrElse(false)) {

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
@@ -6,6 +6,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.TaskProvider;
+import wtf.emulator.EwDeviceSpec;
 import wtf.emulator.EwExecSummaryTask;
 import wtf.emulator.EwExecTask;
 import wtf.emulator.EwExtension;
@@ -139,11 +140,7 @@ public class TaskConfigurator {
 
     task.getRecordVideo().set(ext.getRecordVideo());
 
-    task.getDevices().set(ext.getDevices().map(devices -> devices.stream().map((config) -> {
-      final Map<String, String> out = new HashMap<>();
-      config.forEach((key, value) -> out.put(key, Objects.toString(value)));
-      return out;
-    }).collect(Collectors.toList())));
+    task.getDevices().set(ext.getDevices().stream().map(EwDeviceSpec::toCliMap).collect(Collectors.toList()));
 
     task.getUseOrchestrator().set(ext.getUseOrchestrator().orElse(target.provider(() ->
         android.getTestOptions().getExecution().equalsIgnoreCase("ANDROIDX_TEST_ORCHESTRATOR"))));


### PR DESCRIPTION
Adds a typesafe way to specify device APIs in the Gradle plugin.

Before:

```groovy
emulatorwtf {
    devices = [[model: 'Pixel2', version: 29], [model: 'NexusLowRes', version: 21]]
}
```

After:

```groovy
emulatorwtf {
    device {
        model = PIXEL_2
        version = 29
    }
    device {
        model = NEXUS_LOW_RES
        version = 21
    }
}
```