### PR TITLE
feat: bump default ew-cli to 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The `emulatorwtf` plugin DSL supports the following configuration options:
 
 ```groovy
 emulatorwtf {
-  // CLI version to use, defaults to 0.12.0
-  version = '0.12.0'
+  // CLI version to use, defaults to 0.12.1
+  version = '0.12.1'
 
   // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
   // instead of this or passing this value in via a project property

--- a/README.md
+++ b/README.md
@@ -221,6 +221,19 @@ emulatorwtf {
     }
   }
 
+  // Use a specific DNS server instead of the default one.
+  dnsServers = ["1.1.1.1"]
+  
+  // Redirects all network traffic from the emulator instance to the Gradle plugin
+  // as if you were running the emulator locally.
+  // You can use this to test your app with a local server or an internal
+  // environment only accessible to your local machine or CI runner.
+  egressTunnel = false
+
+  // Makes the machine the Gradle build is running on visible to the emulator under the given ipv4 address,
+  // only works together with the egressTunnel option
+  egressLocalhostForwardIp = "192.168.200.1"
+
   // Configure a HTTP proxy to use when making requests to emulator.wtf API
   // these values default to standard JVM system properties `http.proxyHost`,
   // `http.proxyPort`, `http.proxyUser` and `http.proxyPassword` - there's no need to specify

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The `emulatorwtf` plugin DSL supports the following configuration options:
 
 ```groovy
 emulatorwtf {
-  // CLI version to use, defaults to 0.11.1
-  version = '0.11.1'
+  // CLI version to use, defaults to 0.12.0
+  version = '0.12.0'
 
   // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
   // instead of this or passing this value in via a project property

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ emulatorwtf {
   // for instance to only run medium tests:
   environmentVariables = [size: 'medium']
 
+  // additional arguments to AndroidJUnitRunner, similar to the environmentVariables
+  // above, but in this case the arguments will be hidden in the emulator.wtf UI.
+  // Use this for passing any sort of secrets - tokens, passwords, credentials, etc.
+  secretEnvironmentVariables = [token: 'hunter2']
+
   // Set to the a minutes value to split your tests into multiple shards
   // dynamically, the number of shards will be figured out based on historical
   // test times. This is a good way to ensure a consistent runtime as your

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -5,4 +5,11 @@
 #
 # (Markdown is supported and encouraged)
 
-unreleased: []
+unreleased:
+- "Bumped default `ew-cli` version to 0.12.1"
+- |
+  New: added support for passing secret runner arguments via `secretEnvironmentVariables`, for use with things like
+  tokens, credentials, passwords, etc.
+- |
+  New: added support for tunneling emulator egress networking to the machine the Gradle build is running on. Read more
+  about this feature [here](https://docs.emulator.wtf/concepts/networking/#egress-tunnel).

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwExtension.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwExtension.java
@@ -37,7 +37,7 @@ public abstract class EwExtension implements EwInvokeConfiguration {
 
   @Inject
   public EwExtension(ObjectFactory objectFactory) {
-    getVersion().convention("0.12.0");
+    getVersion().convention("0.12.1");
     getSideEffects().convention(false);
     getOutputs().convention(Collections.emptyList());
 

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwExtension.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwExtension.java
@@ -31,11 +31,13 @@ public abstract class EwExtension implements EwInvokeConfiguration {
 
   public abstract MapProperty<String, Object> getEnvironmentVariables();
 
+  public abstract MapProperty<String, Object> getSecretEnvironmentVariables();
+
   private Action<EwVariantFilter> filter = null;
 
   @Inject
   public EwExtension(ObjectFactory objectFactory) {
-    getVersion().convention("0.11.1");
+    getVersion().convention("0.12.0");
     getSideEffects().convention(false);
     getOutputs().convention(Collections.emptyList());
 

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwInvokeConfiguration.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwInvokeConfiguration.java
@@ -7,59 +7,53 @@ import org.gradle.api.provider.Property;
 import java.time.Duration;
 
 public interface EwInvokeConfiguration {
-  ListProperty<OutputType> getOutputs();
-  Property<Boolean> getRecordVideo();
-
-  Property<Boolean> getUseOrchestrator();
-  Property<Boolean> getClearPackageData();
-  Property<Boolean> getWithCoverage();
-
+  // files
   Property<FileCollection> getAdditionalApks();
-
-  Property<Integer> getNumUniformShards();
-  Property<Integer> getNumShards();
-  Property<Integer> getNumBalancedShards();
-  Property<Integer> getShardTargetRuntime();
-
-  ListProperty<String> getDirectoriesToPull();
-
-  Property<Boolean> getSideEffects();
-
-  Property<Duration> getTimeout();
-
+  Property<Duration> getFileCacheTtl();
   Property<Boolean> getFileCacheEnabled();
 
-  Property<Duration> getFileCacheTtl();
-
-  Property<Boolean> getTestCacheEnabled();
-
-  Property<Integer> getNumFlakyTestAttempts();
-
-  Property<String> getFlakyTestRepeatMode();
-
+  // test config
   Property<String> getDisplayName();
+  Property<Boolean> getUseOrchestrator();
+  Property<Boolean> getClearPackageData();
+  Property<Integer> getNumFlakyTestAttempts();
+  Property<String> getFlakyTestRepeatMode();
+  Property<Duration> getTimeout();
+  Property<String> getTestTargets();
+  Property<Boolean> getTestCacheEnabled();
+  Property<Boolean> getSideEffects();
 
+  // sharding
+  Property<Integer> getNumBalancedShards();
+  Property<Integer> getShardTargetRuntime();
+  Property<Integer> getNumUniformShards();
+  Property<Integer> getNumShards();
+
+  // test outputs
+  Property<Boolean> getRecordVideo();
+  Property<Boolean> getWithCoverage();
+  ListProperty<String> getDirectoriesToPull();
+  ListProperty<OutputType> getOutputs();
+
+  // emulator networking
+  ListProperty<String> getDnsServers();
+  Property<Boolean> getEgressTunnel();
+  Property<String> getEgressLocalhostForwardIp();
+
+  // source control
   Property<String> getScmUrl();
-
   Property<String> getScmCommitHash();
-
+  Property<String> getScmPrUrl();
   Property<String> getScmRefName();
 
-  Property<String> getScmPrUrl();
-
-  Property<Boolean> getIgnoreFailures();
-
-  Property<Boolean> getAsync();
-
-  Property<Boolean> getPrintOutput();
-
-  Property<String> getTestTargets();
-
+  // ew networking
   Property<String> getProxyHost();
-
   Property<Integer> getProxyPort();
-
   Property<String> getProxyUser();
-
   Property<String> getProxyPassword();
+
+  // execution
+  Property<Boolean> getAsync();
+  Property<Boolean> getIgnoreFailures();
+  Property<Boolean> getPrintOutput();
 }

--- a/gradle-plugin-core/src/main/java/wtf/emulator/EwExecTask.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/EwExecTask.java
@@ -94,6 +94,10 @@ public abstract class EwExecTask extends DefaultTask {
 
   @Optional
   @Input
+  public abstract MapProperty<String, String> getSecretEnvironmentVariables();
+
+  @Optional
+  @Input
   public abstract Property<Integer> getNumUniformShards();
 
   @Optional
@@ -143,6 +147,18 @@ public abstract class EwExecTask extends DefaultTask {
   @Optional
   @Input
   public abstract Property<String> getDisplayName();
+
+  @Optional
+  @Input
+  public abstract ListProperty<String> getDnsServers();
+
+  @Optional
+  @Input
+  public abstract Property<Boolean> getEgressTunnel();
+
+  @Optional
+  @Input
+  public abstract Property<String> getEgressLocalhostForwardIp();
 
   @Optional
   @Input
@@ -219,6 +235,7 @@ public abstract class EwExecTask extends DefaultTask {
     p.getWithCoverage().set(getWithCoverage());
     p.getAdditionalApks().set(getAdditionalApks());
     p.getEnvironmentVariables().set(getEnvironmentVariables());
+    p.getSecretEnvironmentVariables().set(getSecretEnvironmentVariables());
     p.getNumUniformShards().set(getNumUniformShards());
     p.getNumBalancedShards().set(getNumBalancedShards());
     p.getNumShards().set(getNumShards());
@@ -232,6 +249,9 @@ public abstract class EwExecTask extends DefaultTask {
     p.getNumFlakyTestAttempts().set(getNumFlakyTestAttempts());
     p.getFlakyTestRepeatMode().set(getFlakyTestRepeatMode());
     p.getDisplayName().set(getDisplayName());
+    p.getDnsServers().set(getDnsServers());
+    p.getEgressTunnel().set(getEgressTunnel());
+    p.getEgressLocalhostForwardIp().set(getEgressLocalhostForwardIp());
     p.getScmUrl().set(getScmUrl());
     p.getScmCommitHash().set(getScmCommitHash());
     p.getScmRefName().set(getScmRefName());

--- a/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCliExecutor.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCliExecutor.java
@@ -306,6 +306,17 @@ public class EwCliExecutor {
       }
     }
 
+    if (parameters.getSecretEnvironmentVariables().isPresent()) {
+      Map<String, String> secretEnv = parameters.getEnvironmentVariables().get();
+      if (!secretEnv.isEmpty()) {
+        String secretEnvLine = secretEnv.entrySet().stream()
+            .filter(entry -> entry.getValue() != null)
+            .map(entry -> entry.getKey() + "=" + entry.getValue())
+            .collect(Collectors.joining(","));
+        spec.args("--secret-environment-variables", secretEnvLine);
+      }
+    }
+
     if (parameters.getShardTargetRuntime().isPresent()) {
       spec.args("--shard-target-runtime", parameters.getShardTargetRuntime().get() + "m");
     } else if (parameters.getNumBalancedShards().isPresent()) {
@@ -351,6 +362,20 @@ public class EwCliExecutor {
 
     if (parameters.getTestTargets().isPresent()) {
       spec.args("--test-targets", parameters.getTestTargets().get());
+    }
+
+    if (parameters.getDnsServers().isPresent()) {
+      parameters.getDnsServers().get().stream().limit(4).forEach(addr -> {
+        spec.args("--dns-server", addr);
+      });
+    }
+
+    if (parameters.getEgressTunnel().isPresent()) {
+      spec.args("--egress-tunnel");
+    }
+
+    if (parameters.getEgressLocalhostForwardIp().isPresent()) {
+      spec.args("--egress-localhost-forward-ip", parameters.getEgressLocalhostForwardIp().get());
     }
 
     if (parameters.getProxyHost().isPresent()) {

--- a/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwWorkParameters.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwWorkParameters.java
@@ -32,6 +32,8 @@ public interface EwWorkParameters extends EwInvokeConfiguration, WorkParameters 
 
   MapProperty<String, String> getEnvironmentVariables();
 
+  MapProperty<String, String> getSecretEnvironmentVariables();
+
   RegularFileProperty getOutputFile();
 
   Property<String> getTaskPath();

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
@@ -167,6 +167,14 @@ public class TaskConfigurator {
           return out;
         }));
 
+    task.getSecretEnvironmentVariables().set(ext.getSecretEnvironmentVariables()
+      .map((entries) -> {
+        // toString the values
+        final Map<String, String> out = new HashMap<>();
+        entries.forEach((key, value) -> out.put(key, Objects.toString(value)));
+        return out;
+      }));
+
     task.getNumUniformShards().set(ext.getNumUniformShards());
     task.getNumShards().set(ext.getNumShards());
     task.getNumBalancedShards().set(ext.getNumBalancedShards());
@@ -192,6 +200,10 @@ public class TaskConfigurator {
     task.getScmCommitHash().set(ext.getScmCommitHash());
     task.getScmRefName().set(ext.getScmRefName());
     task.getScmPrUrl().set(ext.getScmPrUrl());
+
+    task.getDnsServers().set(ext.getDnsServers());
+    task.getEgressTunnel().set(ext.getEgressTunnel());
+    task.getEgressLocalhostForwardIp().set(ext.getEgressLocalhostForwardIp());
 
     task.getPrintOutput().set(ext.getPrintOutput());
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Publishing
 
 GROUP=wtf.emulator
-VERSION_NAME=0.18.1
+VERSION_NAME=0.19.0-SNAPSHOT
 
 POM_NAME=emulator.wtf Gradle Plugin
 POM_DESCRIPTION=With this Gradle plugin you can run your Android instrumentation tests with emulator.wtf


### PR DESCRIPTION
Bump the default `ew-cli` to 0.12.1 and add support for new features like `--egress-tunnel`, `--dns-server` or `--secret-environment-variables`.