### PR TITLE
ci: add missing lint baseline files

### DIFF
--- a/develocity-reporter/src/lint/baseline.xml
+++ b/develocity-reporter/src/lint/baseline.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.11.0-alpha06" type="baseline" client="gradle" dependencies="false" name="AGP (8.11.0-alpha06)" variant="all" version="8.11.0-alpha06">
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of dev.gradleplugins:gradle-api than 7.0 is available: 8.11.1"
+        errorLine1="gradle-api-v70 = &quot;dev.gradleplugins:gradle-api:7.0&quot;"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="18"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of dev.gradleplugins:gradle-api than 7.4 is available: 8.11.1"
+        errorLine1="gradle-api-v74 = &quot;dev.gradleplugins:gradle-api:7.4&quot;"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="19"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of commons-io:commons-io than 2.18.0 is available: 2.19.0"
+        errorLine1="commons-io = &quot;commons-io:commons-io:2.18.0&quot;"
+        errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="29"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="SimilarGradleDependency"
+        message="There are multiple dependencies dev.gradleplugins:gradle-api but with different version"
+        errorLine1="gradle-api-v70 = &quot;dev.gradleplugins:gradle-api:7.0&quot;"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="18"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="SimilarGradleDependency"
+        message="There are multiple dependencies dev.gradleplugins:gradle-api but with different version"
+        errorLine1="gradle-api-v74 = &quot;dev.gradleplugins:gradle-api:7.4&quot;"
+        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="19"
+            column="18"/>
+    </issue>
+
+</issues>

--- a/gradle-compat-8-13/src/lint/baseline.xml
+++ b/gradle-compat-8-13/src/lint/baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.11.0-alpha06" type="baseline" client="gradle" dependencies="false" name="AGP (8.11.0-alpha06)" variant="all" version="8.11.0-alpha06">
+
+</issues>


### PR DESCRIPTION
Unbreak the build by adding the missing lint baseline files for new modules.

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
