### PR TITLE
fix: properly pass secretEnvironmentVariables to ew-cli

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -5,4 +5,5 @@
 #
 # (Markdown is supported and encouraged)
 
-unreleased: []
+unreleased:
+- "Fixed: `secretEnvironmentVariables` were not passed to the emulator correctly and had no effect."

--- a/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCliExecutor.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCliExecutor.java
@@ -307,7 +307,7 @@ public class EwCliExecutor {
     }
 
     if (parameters.getSecretEnvironmentVariables().isPresent()) {
-      Map<String, String> secretEnv = parameters.getEnvironmentVariables().get();
+      Map<String, String> secretEnv = parameters.getSecretEnvironmentVariables().get();
       if (!secretEnv.isEmpty()) {
         String secretEnvLine = secretEnv.entrySet().stream()
             .filter(entry -> entry.getValue() != null)


### PR DESCRIPTION
I must've made a copy-paste error - when `secretEnvironmentVariables` prop was defined we were still passing in `environmentVariables`.

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [x] I have updated the release notes in `changelog.yaml`
