### PR TITLE
fix: fix config cache issues with TestReporter.GRADLE_TEST_REPORTING_API

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -5,4 +5,7 @@
 #
 # (Markdown is supported and encouraged)
 
-unreleased: []
+unreleased:
+- |
+  Fixed `Invocation of 'Task.project' by task '...' at execution time is unsupported` errors when using the configuration cache
+  and `TestReporter.GRADLE_TEST_REPORTING_API` together.

--- a/gradle-compat-7-0/src/main/java/wtf/emulator/GradleCompat_7_0.java
+++ b/gradle-compat-7-0/src/main/java/wtf/emulator/GradleCompat_7_0.java
@@ -2,6 +2,7 @@ package wtf.emulator;
 
 import org.gradle.api.Project;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.model.ObjectFactory;
 import wtf.emulator.junit.JUnitResults;
 
 import javax.annotation.Nullable;
@@ -26,7 +27,7 @@ public class GradleCompat_7_0 implements GradleCompat {
   }
 
   @Override
-  public void reportTestResults(Project project, JUnitResults junitResults, @Nullable String resultsUrl) {
+  public void reportTestResults(ObjectFactory objects, JUnitResults junitResults, @Nullable String resultsUrl) {
     /* intentionally empty */
   }
 }

--- a/gradle-compat-7-4/src/main/java/wtf/emulator/GradleCompat_7_4.java
+++ b/gradle-compat-7-4/src/main/java/wtf/emulator/GradleCompat_7_4.java
@@ -4,6 +4,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.model.ObjectFactory;
 import wtf.emulator.junit.JUnitResults;
 
 import javax.annotation.Nullable;
@@ -27,7 +28,7 @@ public class GradleCompat_7_4 implements GradleCompat {
   }
 
   @Override
-  public void reportTestResults(Project project, JUnitResults junitResults, @Nullable String resultsUrl) {
+  public void reportTestResults(ObjectFactory objects, JUnitResults junitResults, @Nullable String resultsUrl) {
     /* intentionally empty */
   }
 

--- a/gradle-compat-8-13/src/main/java/wtf/emulator/GradleCompat_8_13.java
+++ b/gradle-compat-8-13/src/main/java/wtf/emulator/GradleCompat_8_13.java
@@ -4,6 +4,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Category;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.testing.GroupTestEventReporter;
 import org.gradle.api.tasks.testing.TestEventReporter;
 import org.gradle.api.tasks.testing.TestOutputEvent;
@@ -39,8 +40,8 @@ public class GradleCompat_8_13 implements GradleCompat {
   }
 
   @Override
-  public void reportTestResults(Project project, JUnitResults junitResults, @Nullable String resultsUrl) {
-    TestReportingDepsHolder deps = project.getObjects().newInstance(TestReportingDepsHolder.class);
+  public void reportTestResults(ObjectFactory objects, JUnitResults junitResults, @Nullable String resultsUrl) {
+    TestReportingDepsHolder deps = objects.newInstance(TestReportingDepsHolder.class);
     try (GroupTestEventReporter rootReporter = deps.getTestEventReporterFactory().createTestEventReporter(
       "emulator.wtf",
       deps.getLayout().getBuildDirectory().dir("test-results/emulatorwtf-test").get(),

--- a/gradle-compat-api/src/main/java/wtf/emulator/GradleCompat.java
+++ b/gradle-compat-api/src/main/java/wtf/emulator/GradleCompat.java
@@ -2,6 +2,7 @@ package wtf.emulator;
 
 import org.gradle.api.Project;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.model.ObjectFactory;
 import wtf.emulator.junit.JUnitResults;
 
 import javax.annotation.Nullable;
@@ -14,5 +15,5 @@ public interface GradleCompat {
   
   String getCategoryAttributeVerification();
 
-  void reportTestResults(Project project, JUnitResults junitResults, @Nullable String resultsUrl);
+  void reportTestResults(ObjectFactory objects, JUnitResults junitResults, @Nullable String resultsUrl);
 }

--- a/gradle-compat/src/main/java/wtf/emulator/GradleCompatFactory.java
+++ b/gradle-compat/src/main/java/wtf/emulator/GradleCompatFactory.java
@@ -8,11 +8,15 @@ public class GradleCompatFactory {
   private static final Semver GRADLE_8_13 = new Semver("8.13", Semver.SemverType.LOOSE);
 
   public static GradleCompat get(Gradle gradle) {
-    Semver gradleVersion = new Semver(gradle.getGradleVersion(), Semver.SemverType.LOOSE);
+    return get(gradle.getGradleVersion());
+  }
 
-    if (gradleVersion.isGreaterThanOrEqualTo(GRADLE_8_13)) {
+  public static GradleCompat get(String gradleVersion) {
+    Semver version = new Semver(gradleVersion, Semver.SemverType.LOOSE);
+
+    if (version.isGreaterThanOrEqualTo(GRADLE_8_13)) {
       return new GradleCompat_8_13();
-    } else if (gradleVersion.isGreaterThanOrEqualTo(GRADLE_7_4)) {
+    } else if (version.isGreaterThanOrEqualTo(GRADLE_7_4)) {
       return new GradleCompat_7_4();
     } else {
       return new GradleCompat_7_0();

--- a/gradle-plugin-core/src/main/java/wtf/emulator/EwReportTask.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/EwReportTask.java
@@ -5,9 +5,13 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
@@ -16,6 +20,7 @@ import wtf.emulator.exec.EwCliOutput;
 import wtf.emulator.junit.JUnitResults;
 import wtf.emulator.junit.JUnitXmlParser;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -24,18 +29,24 @@ import java.io.IOException;
 public abstract class EwReportTask extends DefaultTask {
 
   @InputFile
-  @PathSensitive(PathSensitivity.RELATIVE)
+  @PathSensitive(PathSensitivity.NONE)
   public abstract RegularFileProperty getCliOutputFile(); // intermediate json
 
   @InputDirectory
   @PathSensitive(PathSensitivity.RELATIVE)
   public abstract DirectoryProperty getOutputDir();
 
+  @Internal
+  public abstract Property<String> getGradleVersion();
+
   @InputFile
-  @PathSensitive(PathSensitivity.RELATIVE)
+  @PathSensitive(PathSensitivity.NONE)
   Provider<RegularFile> getMergedXml() {
     return getOutputDir().file("results.xml");
   }
+
+  @Inject
+  public abstract ObjectFactory getObjects();
 
   @TaskAction
   public void exec() {
@@ -55,7 +66,7 @@ public abstract class EwReportTask extends DefaultTask {
     if (sync != null) {
       resultsUrl = sync.resultsUrl();
     }
-    GradleCompatFactory.get(getProject().getGradle()).reportTestResults(getProject(), jUnitResults, resultsUrl);
+    GradleCompatFactory.get(getGradleVersion().get()).reportTestResults(getObjects(), jUnitResults, resultsUrl);
   }
 
   private static EwCliOutput readOutput(File file) {

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
@@ -123,6 +123,7 @@ public class TaskConfigurator {
           TaskProvider<? extends EwReportTask> reportTask = target.getTasks().register(reportTaskName, EwReportTask.class, task -> {
             task.getCliOutputFile().set(execTask.flatMap(EwExecTask::getOutputFile));
             task.getOutputDir().set(execTask.flatMap(EwExecTask::getOutputsDir));
+            task.getGradleVersion().set(target.getGradle().getGradleVersion());
           });
           execTask.configure(task -> task.finalizedBy(reportTask));
           break;

--- a/integration-test/project-isolation/app/build.gradle.kts
+++ b/integration-test/project-isolation/app/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
   id("wtf.emulator.gradle")
 }
 
+import wtf.emulator.TestReporter
+
 android {
   compileSdk = 34
 
@@ -35,4 +37,8 @@ dependencies {
   androidTestImplementation("com.google.truth:truth:1.4.4")
 
   testImplementation("junit:junit:4.13.2")
+}
+
+emulatorwtf {
+  testReporters = listOf(TestReporter.GRADLE_TEST_REPORTING_API)
 }


### PR DESCRIPTION
Use of `Project` during task execution is disallowed with config cache now. Removes direct access to `Project` from inside the `EwReportTask` by directly injecting `ObjectFactory` and passing in the Gradle version instead of doing a `getProject().getGradle()` call.

Also added the `GRADLE_TEST_REPORTING_API` test reporter to the project-isolation/config-cache integration test.

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [x] I have updated the release notes in `changelog.yaml`
