### PR TITLE
chore: set development version to 0.19.3-SNAPSHOT

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -5,9 +5,4 @@
 #
 # (Markdown is supported and encouraged)
 
-unreleased:
-- |
-  Fixed `Invocation of 'Task.project' by task '...' at execution time is unsupported` errors when using the configuration cache
-  and `TestReporter.GRADLE_TEST_REPORTING_API` together.
-- |
-  Fixed: no test results were reported to the Gradle Test Reporting API when the test task failed
+unreleased: []

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Publishing
 
 GROUP=wtf.emulator
-VERSION_NAME=0.19.2
+VERSION_NAME=0.19.3-SNAPSHOT
 
 POM_NAME=emulator.wtf Gradle Plugin
 POM_DESCRIPTION=With this Gradle plugin you can run your Android instrumentation tests with emulator.wtf


### PR DESCRIPTION
Set development version to `0.19.3-SNAPSHOT` and clear the changenotes.

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
