### PR TITLE
fix(gmd): use user supplied device name in XML test results

### DIFF
--- a/gradle-plugin-core/src/main/java/wtf/emulator/gmd/EwDeviceTestRunTaskAction.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/gmd/EwDeviceTestRunTaskAction.java
@@ -201,7 +201,7 @@ public abstract class EwDeviceTestRunTaskAction implements DeviceTestRunTaskActi
         File renamedResultsXml = new File(outputsDir, "TEST-results.xml");
         if (resultsXml.renameTo(renamedResultsXml)) {
           // Extract required metadata from deviceTestRunParameters
-          String deviceName = deviceTestRunParameters.getDeviceInput().getDevice().get();
+          String deviceName = deviceTestRunParameters.getTestRunData().getDeviceName();
           String flavor = deviceTestRunParameters.getTestRunData().getTestData().getFlavorName();
           String projectName = deviceTestRunParameters.getTestRunData().getProjectPath();
 


### PR DESCRIPTION
_Short description of the changes goes here_

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
