### PR TITLE
feat!: automatically add test-runtime-android dependency

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -6,12 +6,13 @@
 # (Markdown is supported and encouraged)
 
 unreleased:
+- "Breaking: minimum supported Android Gradle Plugin version is now 8.1"
+- "Breaking: minimum supported Gradle version is now 8.0"
+- "Breaking: emulator.wtf Gradle plugin only works on JDK 17 and later"
+- "Added support for Gradle-managed devices"
+- "Added support for generating baseline profiles via the `baselineprofile` plugin when using Gradle-managed devices"
 - |
-  Add support for Gradle-managed devices
-- |
-  Add support for generating baseline profiles via the `baselineprofile` plugin
-- |
-  Bump min supported AGP version to 8.1
-- |
-  Bump min supported Gradle version to 8.1
-- Bump min supported Gradle version to 8.0 and JDK to 17
+  When applied to Android projects the emulator.wtf Gradle plugin now automatically adds the
+  [`wtf.emulator:test-runtime-android`](https://github.com/emulator-wtf/test-runtime-android) dependency to the
+  `androidTestImplementation` configuration to enable per-test video captures. You can disable this by adding
+  `wtf.emulator.addruntimedependency=false` to your `gradle.properties` file.

--- a/gradle-plugin-api/build.gradle.kts
+++ b/gradle-plugin-api/build.gradle.kts
@@ -28,5 +28,16 @@ dependencies {
 
 buildConfig {
   packageName("wtf.emulator")
-  buildConfigField("String", "VERSION", "\"${providers.gradleProperty("VERSION_NAME").orNull ?: project.version}\"")
+
+  // version of the Gradle plugin
+  buildConfigField("VERSION", providers.gradleProperty("VERSION_NAME").orElse(project.version.toString()))
+
+  // Maven coordinates for cli without version
+  buildConfigField("EW_CLI_MODULE", libs.emulatorwtf.cli.map { it.module.toString() })
+
+  // Cli version to use by default
+  buildConfigField("EW_CLI_VERSION", libs.emulatorwtf.cli.map { it.version!! })
+
+  // Full maven coordinates for runtime, including version
+  buildConfigField("EW_RUNTIME_COORDS", libs.emulatorwtf.runtime.map { it.toString() })
 }

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwExtension.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwExtension.java
@@ -41,7 +41,7 @@ public abstract class EwExtension implements EwInvokeConfiguration {
 
   @Inject
   public EwExtension(ObjectFactory objectFactory) {
-    getVersion().convention("0.12.1");
+    getVersion().convention(BuildConfig.EW_CLI_VERSION);
     getSideEffects().convention(false);
     getOutputs().convention(Collections.emptyList());
 

--- a/gradle-plugin-core/src/main/java/wtf/emulator/EwProperties.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/EwProperties.java
@@ -3,7 +3,8 @@ package wtf.emulator;
 import org.gradle.api.Project;
 
 public enum EwProperties {
-  ADD_REPOSITORY("addrepository");
+  ADD_REPOSITORY("addrepository"),
+  ADD_RUNTIME_DEPENDENCY("addruntimedependency");
 
   private static final String PREFIX = "wtf.emulator";
 

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProjectConfigurator.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProjectConfigurator.java
@@ -22,6 +22,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.provider.Provider;
+import wtf.emulator.BuildConfig;
 import wtf.emulator.EwExtension;
 import wtf.emulator.EwExtensionInternal;
 import wtf.emulator.EwProperties;
@@ -62,6 +63,7 @@ public class ProjectConfigurator {
   public void configure() {
     setupExtensionDefaults();
     configureRepository();
+    configureRuntimeDependency();
 
     Provider<Configuration> toolConfig = createToolConfiguration();
     Configuration resultsExportConfig = createResultsExportConfiguration();
@@ -160,6 +162,20 @@ public class ProjectConfigurator {
     ext.getRepositoryCheckEnabled().convention(true);
   }
 
+  private void configureRuntimeDependency() {
+    if (!EwProperties.ADD_RUNTIME_DEPENDENCY.getFlag(target, true)) {
+      return;
+    }
+
+    Runnable adder = () ->
+      target.getConfigurations().named("androidTestImplementation", config ->
+        config.getDependencies().add(target.getDependencies().create(BuildConfig.EW_RUNTIME_COORDS)));
+
+    target.getPluginManager().withPlugin("com.android.application", plugin -> adder.run());
+    target.getPluginManager().withPlugin("com.android.library", plugin -> adder.run());
+    target.getPluginManager().withPlugin("com.android.test", plugin -> adder.run());
+  }
+
   private void configureRepository() {
     if (!EwProperties.ADD_REPOSITORY.getFlag(target, true)) {
       return;
@@ -204,7 +220,7 @@ public class ProjectConfigurator {
       config.setVisible(false);
       config.setCanBeConsumed(false);
       config.setCanBeResolved(true);
-      target.getDependencies().add(TOOL_CONFIGURATION, ext.getVersion().map(version -> "wtf.emulator:ew-cli:" + version));
+      target.getDependencies().add(TOOL_CONFIGURATION, ext.getVersion().map(version -> BuildConfig.EW_CLI_MODULE + ":" + version));
     });
     return toolConfig;
   }

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProjectConfigurator.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProjectConfigurator.java
@@ -167,13 +167,14 @@ public class ProjectConfigurator {
       return;
     }
 
-    Runnable adder = () ->
-      target.getConfigurations().named("androidTestImplementation", config ->
-        config.getDependencies().add(target.getDependencies().create(BuildConfig.EW_RUNTIME_COORDS)));
+    target.getPluginManager().withPlugin("com.android.application", plugin -> addRuntimeDependency("androidTestImplementation"));
+    target.getPluginManager().withPlugin("com.android.library", plugin -> addRuntimeDependency("androidTestImplementation"));
+    target.getPluginManager().withPlugin("com.android.test", plugin -> addRuntimeDependency("implementation"));
+  }
 
-    target.getPluginManager().withPlugin("com.android.application", plugin -> adder.run());
-    target.getPluginManager().withPlugin("com.android.library", plugin -> adder.run());
-    target.getPluginManager().withPlugin("com.android.test", plugin -> adder.run());
+  private void addRuntimeDependency(String configurationName) {
+    target.getConfigurations().named(configurationName, config ->
+      config.getDependencies().add(target.getDependencies().create(BuildConfig.EW_RUNTIME_COORDS)));
   }
 
   private void configureRepository() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,5 +41,8 @@ autovalue-gson-runtime = { module = "com.ryanharter.auto.value:auto-value-gson-r
 autovalue-gson-extension = { module = "com.ryanharter.auto.value:auto-value-gson-extension", version.ref = "autovalue-gson" }
 autovalue-gson-factory = { module = "com.ryanharter.auto.value:auto-value-gson-factory", version.ref = "autovalue-gson" }
 
+emulatorwtf-cli = "wtf.emulator:ew-cli:0.12.1"
+emulatorwtf-runtime = "wtf.emulator:test-runtime-android:0.2.1"
+
 [bundles]
 test = ["junit", "truth"]

--- a/integration-test/latest/build.gradle.kts
+++ b/integration-test/latest/build.gradle.kts
@@ -28,7 +28,7 @@ android {
 }
 
 dependencies {
-  androidTestImplementation("wtf.emulator:test-runtime-android:0.2.1")
+//  androidTestImplementation("wtf.emulator:test-runtime-android:0.2.1")
   androidTestImplementation("androidx.test:rules:1.6.1")
   androidTestImplementation("androidx.test:runner:1.6.2")
   androidTestImplementation("androidx.test:core:1.6.1")

--- a/integration-test/latest/build.gradle.kts
+++ b/integration-test/latest/build.gradle.kts
@@ -28,7 +28,6 @@ android {
 }
 
 dependencies {
-//  androidTestImplementation("wtf.emulator:test-runtime-android:0.2.1")
   androidTestImplementation("androidx.test:rules:1.6.1")
   androidTestImplementation("androidx.test:runner:1.6.2")
   androidTestImplementation("androidx.test:core:1.6.1")

--- a/integration-test/oldest/app/build.gradle
+++ b/integration-test/oldest/app/build.gradle
@@ -30,7 +30,6 @@ android {
 dependencies {
   implementation(project(":library"))
 
-  androidTestImplementation 'wtf.emulator:test-runtime-android:0.2.0'
   androidTestImplementation 'androidx.test:rules:1.5.0'
   androidTestImplementation 'androidx.test:runner:1.5.2'
   androidTestImplementation 'androidx.test:core:1.5.0'

--- a/integration-test/oldest/library/build.gradle
+++ b/integration-test/oldest/library/build.gradle
@@ -27,7 +27,6 @@ android {
 }
 
 dependencies {
-  androidTestImplementation 'wtf.emulator:test-runtime-android:0.2.0'
   androidTestImplementation 'androidx.test:rules:1.5.0'
   androidTestImplementation 'androidx.test:runner:1.5.2'
   androidTestImplementation 'androidx.test:core:1.5.0'

--- a/integration-test/oldest/test/build.gradle
+++ b/integration-test/oldest/test/build.gradle
@@ -29,7 +29,6 @@ android {
 }
 
 dependencies {
-  implementation 'wtf.emulator:test-runtime-android:0.2.0'
   implementation 'androidx.test:rules:1.5.0'
   implementation 'androidx.test:runner:1.5.2'
   implementation 'androidx.test:core:1.5.0'

--- a/integration-test/project-isolation/app/build.gradle.kts
+++ b/integration-test/project-isolation/app/build.gradle.kts
@@ -29,7 +29,6 @@ android {
 dependencies {
   implementation(project(":library"))
 
-  androidTestImplementation("wtf.emulator:test-runtime-android:0.2.0")
   androidTestImplementation("androidx.test:rules:1.6.1")
   androidTestImplementation("androidx.test:runner:1.6.2")
   androidTestImplementation("androidx.test:core:1.6.1")

--- a/integration-test/project-isolation/library/build.gradle.kts
+++ b/integration-test/project-isolation/library/build.gradle.kts
@@ -21,7 +21,6 @@ android {
 }
 
 dependencies {
-  androidTestImplementation("wtf.emulator:test-runtime-android:0.2.0")
   androidTestImplementation("androidx.test:rules:1.6.1")
   androidTestImplementation("androidx.test:runner:1.6.2")
   androidTestImplementation("androidx.test:core:1.6.1")

--- a/integration-test/project-isolation/test/build.gradle.kts
+++ b/integration-test/project-isolation/test/build.gradle.kts
@@ -24,7 +24,6 @@ android {
 }
 
 dependencies {
-  implementation("wtf.emulator:test-runtime-android:0.2.0")
   implementation("androidx.test:rules:1.6.1")
   implementation("androidx.test:runner:1.6.2")
   implementation("androidx.test:core:1.6.1")


### PR DESCRIPTION
Always adds the `wtf.emulator:test-runtime-android` dependency to `androidTestImplementation` configurations on `com.android.application`, `com.android.library` and `com.android.test` projects.

Users can disable this behaviour with the `wtf.emulator.addruntimedependency` Gradle property.

The module coords and version is taken from the Gradle version catalog while building the plugin. This way we get auto-updates from dependabot while downstream users will always get a fixed version tied to the emulator.wtf Gradle plugin version. I converted the CLI version to use this pattern as well.

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [x] I have updated the release notes in `changelog.yaml`
