### PR TITLE
chore: run tests via GMD as part of integration tests

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -36,4 +36,4 @@ runs:
     env:
       EW_API_TOKEN: ${{ inputs.gh-token }}
     working-directory: integration-test/${{ inputs.test-project }}
-    run: ./gradlew :testWithEmulatorWtf
+    run: ./gradlew :testWithEmulatorWtf :ewPixel7api33DebugAndroidTest

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ baselineProfile {
 <summary>Groovy DSL</summary>
 
 ```groovy
-import wtf.emulator.ewDevices
+import wtf.emulator.gmd.EwManagedDevice
 import wtf.emulator.DeviceModel
 
 android {

--- a/integration-test/abi-splits/app/build.gradle
+++ b/integration-test/abi-splits/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'wtf.emulator.gradle'
 
+import wtf.emulator.gmd.EwManagedDevice
 import wtf.emulator.DeviceModel
 
 android {
@@ -36,6 +37,13 @@ android {
   }
 
   namespace 'wtf.emulator.sample'
+
+  testOptions.managedDevices.allDevices {
+    register("ewPixel7api33", EwManagedDevice) {
+      device = DeviceModel.PIXEL_7
+      apiLevel = 33
+    }
+  }
 }
 
 dependencies {

--- a/integration-test/latest/build.gradle.kts
+++ b/integration-test/latest/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
   id("org.jetbrains.kotlinx.kover") version "0.9.1"
 }
 
+import wtf.emulator.ewDevices
+import wtf.emulator.DeviceModel
+
 android {
   compileSdk = 33
 
@@ -23,6 +26,13 @@ android {
   }
 
   namespace = "wtf.emulator.sample"
+
+  testOptions.managedDevices.ewDevices {
+    register("ewPixel7api33") {
+      device = DeviceModel.PIXEL_7
+      apiLevel = 33
+    }
+  }
 }
 
 dependencies {

--- a/integration-test/oldest/app/build.gradle
+++ b/integration-test/oldest/app/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.application'
 apply plugin: 'wtf.emulator.gradle'
 
+import wtf.emulator.gmd.EwManagedDevice
+import wtf.emulator.DeviceModel
+
 android {
   compileSdkVersion 27
 
@@ -25,6 +28,13 @@ android {
   }
 
   namespace 'wtf.emulator.sample'
+
+  testOptions.managedDevices.allDevices {
+    register("ewPixel7api33", EwManagedDevice) {
+      device = DeviceModel.PIXEL_7
+      apiLevel = 33
+    }
+  }
 }
 
 dependencies {

--- a/integration-test/oldest/gradle.properties
+++ b/integration-test/oldest/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
+android.experimental.testOptions.managedDevices.customDevice=true

--- a/integration-test/oldest/library/build.gradle
+++ b/integration-test/oldest/library/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.library'
 apply plugin: 'wtf.emulator.gradle'
 
+import wtf.emulator.gmd.EwManagedDevice
+import wtf.emulator.DeviceModel
+
 android {
   compileSdkVersion 27
 
@@ -24,6 +27,13 @@ android {
   }
 
   namespace 'wtf.emulator.sample.library'
+
+  testOptions.managedDevices.allDevices {
+    register("ewPixel7api33", EwManagedDevice) {
+      device = DeviceModel.PIXEL_7
+      apiLevel = 33
+    }
+  }
 }
 
 dependencies {

--- a/integration-test/oldest/test/build.gradle
+++ b/integration-test/oldest/test/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'com.android.test'
 apply plugin: 'wtf.emulator.gradle'
 
+import wtf.emulator.gmd.EwManagedDevice
+import wtf.emulator.DeviceModel
+
 android {
   compileSdkVersion 27
 
@@ -26,6 +29,13 @@ android {
   }
 
   namespace 'wtf.emulator.sample.test'
+
+  testOptions.managedDevices.allDevices {
+    register("ewPixel7api33", EwManagedDevice) {
+      device = DeviceModel.PIXEL_7
+      apiLevel = 33
+    }
+  }
 }
 
 dependencies {

--- a/integration-test/oldest/test/src/main/AndroidManifest.xml
+++ b/integration-test/oldest/test/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="wtf.emulator.sample.test">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/integration-test/project-isolation/app/build.gradle.kts
+++ b/integration-test/project-isolation/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   id("wtf.emulator.gradle")
 }
 
+import wtf.emulator.ewDevices
 import wtf.emulator.TestReporter
 import wtf.emulator.DeviceModel
 
@@ -25,6 +26,13 @@ android {
   }
 
   namespace = "wtf.emulator.sample"
+
+  testOptions.managedDevices.ewDevices {
+    register("ewPixel7api33") {
+      device = DeviceModel.PIXEL_7
+      apiLevel = 33
+    }
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Add GMD configurations to all integration tests 

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
