### PR TITLE
chore: run integration tests with and without config cache

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -12,6 +12,10 @@ inputs:
   gh-token:
     description: 'GitHub token'
     required: true
+  config-cache:
+    description: 'Enable Gradle configuration cache'
+    required: false
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -36,4 +40,10 @@ runs:
     env:
       EW_API_TOKEN: ${{ inputs.gh-token }}
     working-directory: integration-test/${{ inputs.test-project }}
-    run: ./gradlew :testWithEmulatorWtf ewPixel7api33DebugAndroidTest :app:validateBaselineProfile
+    run: |
+      CONFIG_CACHE_ARG="--no-configuration-cache"
+      if [ "${{ inputs.configuration-cache }}" == "true" ]; then
+        CONFIG_CACHE_ARG="--configuration-cache"
+      fi
+      ./gradlew :testWithEmulatorWtf ewPixel7api33DebugAndroidTest :app:validateBaselineProfile $CONFIG_CACHE_ARG
+

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -42,7 +42,7 @@ runs:
     working-directory: integration-test/${{ inputs.test-project }}
     run: |
       CONFIG_CACHE_ARG="--no-configuration-cache"
-      if [ "${{ inputs.configuration-cache }}" == "true" ]; then
+      if [ "${{ inputs.config-cache }}" == "true" ]; then
         CONFIG_CACHE_ARG="--configuration-cache"
       fi
       ./gradlew :testWithEmulatorWtf ewPixel7api33DebugAndroidTest :app:validateBaselineProfile $CONFIG_CACHE_ARG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,8 @@ jobs:
         exclude:
           - test-project: 'project-isolation'
             config-cache: 'false'
+          - test-project: 'oldest'
+            config-cache: 'true'
 
     env:
       EW_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,15 @@ jobs:
         include:
           - test-project: 'project-isolation'
             jdk-version: '21'
-            config-cache: 'true'
           - test-project: 'latest'
             jdk-version: '24'
           - test-project: 'oldest'
             jdk-version: '17'
           - test-project: 'abi-splits'
             jdk-version: '20'
+        exclude:
+          - test-project: 'project-isolation'
+            config-cache: 'false'
 
     env:
       EW_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           path: build/maven-repo/
 
   test:
-    name: "Integration test: ${{ matrix.test-project }} (config-cache: ${{ matrix.config-cache }})"
+    name: "${{ matrix.test-project }} (config-cache: ${{ matrix.config-cache }})"
     runs-on: ubuntu-latest
     needs: build
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        test-project: [ 'latest', 'project-isolation', 'oldest', 'abi-splits' ]
         config-cache: [ true, false ]
         include:
           - test-project: 'project-isolation'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           path: build/maven-repo/
 
   test:
+    name: "Integration test: ${{ matrix.test-project }} (config-cache: ${{ matrix.config-cache }})"
     runs-on: ubuntu-latest
     needs: build
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,11 @@ jobs:
       fail-fast: false
       matrix:
         test-project: [ 'latest', 'project-isolation', 'oldest', 'abi-splits' ]
-        config-cache: [ true, false ]
+        config-cache: [ 'true', 'false' ]
         include:
           - test-project: 'project-isolation'
             jdk-version: '21'
+            config-cache: 'true'
           - test-project: 'latest'
             jdk-version: '24'
           - test-project: 'oldest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,58 +26,31 @@ jobs:
           name: gradle-plugin-repo
           path: build/maven-repo/
 
-  test-project-isolation:
+  test:
     runs-on: ubuntu-latest
     needs: build
-    env:
-      EW_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/run-integration-tests
-        name: "Run integration tests against latest Gradle/AGP w/ project-isolation and config cache"
-        with:
-          jdk-version: '21'
-          test-project: 'project-isolation'
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config-cache: [ true, false ]
+        include:
+          - test-project: 'project-isolation'
+            jdk-version: '21'
+          - test-project: 'latest'
+            jdk-version: '24'
+          - test-project: 'oldest'
+            jdk-version: '17'
+          - test-project: 'abi-splits'
+            jdk-version: '20'
 
-  test-latest:
-    runs-on: ubuntu-latest
-    needs: build
     env:
       EW_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/run-integration-tests
-        name: "Run integration tests against latest Gradle/AGP"
+        name: "Run integration tests for ${{ matrix.test-project }} (config-cache: ${{ matrix.config-cache }})"
         with:
-          jdk-version: '24'
-          test-project: 'latest'
+          jdk-version: ${{ matrix.jdk-version }}
+          test-project: ${{ matrix.test-project }}
           gh-token: ${{ secrets.GITHUB_TOKEN }}
-
-  test-oldest:
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      EW_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/run-integration-tests
-        name: "Run integration tests against oldest supported Gradle/AGP"
-        with:
-          jdk-version: '17'
-          test-project: 'oldest'
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
-
-  test-abi-splits:
-    runs-on: ubuntu-latest
-    needs: build
-    env:
-      EW_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/run-integration-tests
-        name: "Run integration tests against various ABI splits"
-        with:
-          jdk-version: '20'
-          test-project: 'abi-splits'
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          config-cache: ${{ matrix.config-cache }}

--- a/integration-test/abi-splits/gradle.properties
+++ b/integration-test/abi-splits/gradle.properties
@@ -1,2 +1,1 @@
 android.useAndroidX=true
-org.gradle.configuration-cache=true

--- a/integration-test/oldest/gradle.properties
+++ b/integration-test/oldest/gradle.properties
@@ -1,4 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
 android.experimental.testOptions.managedDevices.customDevice=true
-org.gradle.configuration-cache=true

--- a/integration-test/project-isolation/gradle.properties
+++ b/integration-test/project-isolation/gradle.properties
@@ -1,3 +1,2 @@
 android.useAndroidX=true
 org.gradle.unsafe.isolated-projects=true
-org.gradle.configuration-cache=true


### PR DESCRIPTION
Run all integration tests with both the configuration cache enabled and disabled.

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
