### PR TITLE
build(deps): bump Gradle in integration-test/latest to 9.0.0-rc-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ The plugin is compatible with any working combination of these ranges:
 | Component             | Oldest | Newest         |
 |-----------------------|--------|----------------|
 | JDK                   | 11     | 24             |
-| Gradle                | 7.0.2  | 9.0.0-rc-1     |
+| Gradle                | 7.0.2  | 9.0.0-rc-2     |
 | Android Gradle Plugin | 7.0.0  | 8.12.0-alpha08 |
 
 NOTE: only the latest of any prerelease versions (`alpha`, `beta`, `rc`) is supported.

--- a/integration-test/latest/gradle/wrapper/gradle-wrapper.properties
+++ b/integration-test/latest/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-rc-2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bump Gradle in `integration-test/latest` to 9.0.0-rc-2.

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
