### PR TITLE
chore: bump default ew-cli to 0.12.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The `emulatorwtf` plugin DSL supports the following configuration options:
 
 ```groovy
 emulatorwtf {
-  // CLI version to use, defaults to 0.12.1
-  version = '0.12.1'
+  // CLI version to use, defaults to 0.12.5
+  version = '0.12.5'
 
   // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
   // instead of this or passing this value in via a project property

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -5,4 +5,6 @@
 #
 # (Markdown is supported and encouraged)
 
-unreleased: []
+unreleased:
+- "Improved: better upload performance when testing large apk files containing native libraries."
+- "Improved: bumped default `ew-cli` version to 0.12.5."

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwExtension.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwExtension.java
@@ -39,7 +39,7 @@ public abstract class EwExtension implements EwInvokeConfiguration {
 
   @Inject
   public EwExtension(ObjectFactory objectFactory) {
-    getVersion().convention("0.12.1");
+    getVersion().convention("0.12.5");
     getSideEffects().convention(false);
     getOutputs().convention(Collections.emptyList());
 


### PR DESCRIPTION
Updated default `ew-cli` to 0.12.5.

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [x] I have updated the release notes in `changelog.yaml`
