### PR TITLE
chore: fix NexusLowResAtd usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ emulatorwtf {
 
   // devices to test on, Defaults to [[model: 'Pixel2', version: 27]]
   devices = [
-    [model: 'NexusLowRes', version: 30, atd: true],
+    [model: 'NexusLowResAtd', version: 30],
     [model: 'Pixel2', version: 23]
   ]
 


### PR DESCRIPTION
The `atd=true` format has been superseded by `*Atd` models for a long while now, bring the relevant example up to speed.

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
