### PR TITLE
chore: bump ew-cli to 1.0.0-rc01

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The `emulatorwtf` plugin DSL supports the following configuration options:
 
 ```groovy
 emulatorwtf {
-  // CLI version to use, defaults to 0.12.6
-  version = '0.12.6'
+  // CLI version to use, defaults to 1.0.0-rc01
+  version = '1.0.0-rc01'
 
   // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
   // instead of this or passing this value in via a project property

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -24,7 +24,8 @@ unreleased:
   }
   ```
 - |
-  When applied to Android projects the emulator.wtf Gradle plugin now automatically adds the
+  Breaking: when applied to Android projects the emulator.wtf Gradle plugin now automatically adds the
   [`wtf.emulator:test-runtime-android`](https://github.com/emulator-wtf/test-runtime-android) dependency to the
   `androidTestImplementation` configuration to enable per-test video captures. You can disable this by adding
   `wtf.emulator.addruntimedependency=false` to your `gradle.properties` file.
+- "Maintenance: ew-cli version bumped to 1.0.0-rc01"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ autovalue-gson-runtime = { module = "com.ryanharter.auto.value:auto-value-gson-r
 autovalue-gson-extension = { module = "com.ryanharter.auto.value:auto-value-gson-extension", version.ref = "autovalue-gson" }
 autovalue-gson-factory = { module = "com.ryanharter.auto.value:auto-value-gson-factory", version.ref = "autovalue-gson" }
 
-emulatorwtf-cli = "wtf.emulator:ew-cli:0.12.1"
+emulatorwtf-cli = "wtf.emulator:ew-cli:1.0.0-rc01"
 emulatorwtf-runtime = "wtf.emulator:test-runtime-android:0.2.1"
 
 [bundles]


### PR DESCRIPTION
Prepping for `gradle-plugin` 1.0.0-rc01 release.

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [x] I have updated the release notes in `changelog.yaml`
