### PR TITLE
fix: make no assumptions about cli defaults in the Gradle plugin

### DIFF
--- a/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCliExecutor.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCliExecutor.java
@@ -345,7 +345,9 @@ public class EwCliExecutor {
       } else {
         spec.args("--no-file-cache");
       }
-    } else if (parameters.getFileCacheTtl().isPresent()) {
+    }
+
+    if (parameters.getFileCacheTtl().isPresent()) {
       spec.args("--file-cache-ttl", toCliString(parameters.getFileCacheTtl().get()));
     }
 


### PR DESCRIPTION
Current logic assumed the defaults were `--no-video`, `--file-cache` and `--test-cache`.
With `1.0.0-rc01` the CLI default i `--video` instead. Overall takes the approach where the configured value is respected and if it is not configured then CLI default is used (by passing no argument at all).

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
