### PR TITLE
feat: add emulatorWtfConnectivityCheck task

### DIFF
--- a/gradle-plugin-core/src/main/java/wtf/emulator/EwConnectivityCheckTask.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/EwConnectivityCheckTask.java
@@ -1,0 +1,100 @@
+package wtf.emulator;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.workers.WorkQueue;
+import org.gradle.workers.WorkerExecutor;
+import wtf.emulator.exec.EwConnectivityCheckWorkAction;
+import wtf.emulator.exec.EwConnectivityCheckWorkParameters;
+
+import javax.inject.Inject;
+
+public abstract class EwConnectivityCheckTask extends DefaultTask {
+  @Classpath
+  @InputFiles
+  public abstract Property<FileCollection> getClasspath();
+
+  @Input
+  public abstract Property<String> getToken();
+
+  @Optional
+  @Input
+  public abstract Property<String> getProxyHost();
+
+  @Optional
+  @Input
+  public abstract Property<Integer> getProxyPort();
+
+  @Optional
+  @Input
+  public abstract Property<String> getProxyUser();
+
+  @Optional
+  @Input
+  public abstract Property<String> getProxyPassword();
+
+  @Optional
+  @Input
+  public abstract ListProperty<String> getDnsServers();
+
+  @Optional
+  @Input
+  public abstract ListProperty<DnsOverride> getDnsOverrides();
+
+  @Optional
+  @Input
+  public abstract ListProperty<String> getRelays();
+
+  @Optional
+  @Input
+  public abstract Property<Boolean> getEgressTunnel();
+
+  @Optional
+  @Input
+  public abstract Property<String> getEgressLocalhostForwardIp();
+
+  @Optional
+  @Input
+  public abstract Property<Boolean> getDebug();
+
+  @Optional
+  @Input
+  public abstract Property<Boolean> getVerbose();
+
+  @Optional
+  @Input
+  public abstract Property<Boolean> getPrintOutput();
+
+  @Inject
+  public abstract WorkerExecutor getWorkerExecutor();
+
+  @TaskAction
+  void run() {
+    WorkQueue workQueue = getWorkerExecutor().noIsolation();
+    workQueue.submit(EwConnectivityCheckWorkAction.class, this::fillWorkParameters);
+  }
+
+  protected void fillWorkParameters(EwConnectivityCheckWorkParameters p) {
+    p.getClasspath().set(getClasspath().get().getFiles());
+    p.getToken().set(getToken());
+    p.getProxyHost().set(getProxyHost());
+    p.getProxyPort().set(getProxyPort());
+    p.getProxyUser().set(getProxyUser());
+    p.getProxyPassword().set(getProxyPassword());
+    p.getDnsServers().set(getDnsServers());
+    p.getDnsOverrides().set(getDnsOverrides());
+    p.getEgressTunnel().set(getEgressTunnel());
+    p.getEgressLocalhostForwardIp().set(getEgressLocalhostForwardIp());
+    p.getRelays().set(getRelays());
+    p.getDebug().set(getDebug());
+    p.getVerbose().set(getVerbose());
+    p.getPrintOutput().set(getPrintOutput());
+  }
+}

--- a/gradle-plugin-core/src/main/java/wtf/emulator/EwExecSummaryTask.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/EwExecSummaryTask.java
@@ -65,6 +65,10 @@ public abstract class EwExecSummaryTask extends DefaultTask {
 
   @Optional
   @Input
+  public abstract Property<Boolean> getDebug();
+
+  @Optional
+  @Input
   public abstract Property<String> getProxyHost();
 
   @Optional
@@ -175,6 +179,7 @@ public abstract class EwExecSummaryTask extends DefaultTask {
     p.getOutputFile().set(summaryOut);
     p.getOutputs().set(getOutputTypes());
     p.getPrintOutput().set(getPrintOutput());
+    p.getDebug().set(getDebug());
     p.getProxyHost().set(getProxyHost());
     p.getProxyPort().set(getProxyPort());
     p.getProxyUser().set(getProxyUser());

--- a/gradle-plugin-core/src/main/java/wtf/emulator/EwExecTask.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/EwExecTask.java
@@ -216,6 +216,10 @@ public abstract class EwExecTask extends DefaultTask {
 
   @Optional
   @Input
+  public abstract Property<Boolean> getDebug();
+
+  @Optional
+  @Input
   public abstract Property<TestTargetsSpec> getTestTargets();
 
   @Optional
@@ -283,6 +287,7 @@ public abstract class EwExecTask extends DefaultTask {
     p.getIgnoreFailures().set(getIgnoreFailures());
     p.getAsync().set(getAsync());
     p.getPrintOutput().set(getPrintOutput());
+    p.getDebug().set(getDebug());
     p.getTestTargets().set(getTestTargets());
     p.getProxyHost().set(getProxyHost());
     p.getProxyPort().set(getProxyPort());

--- a/gradle-plugin-core/src/main/java/wtf/emulator/EwProperties.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/EwProperties.java
@@ -1,10 +1,13 @@
 package wtf.emulator;
 
 import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
 
 public enum EwProperties {
   ADD_REPOSITORY("addrepository"),
-  ADD_RUNTIME_DEPENDENCY("addruntimedependency");
+  ADD_RUNTIME_DEPENDENCY("addruntimedependency"),
+  DEBUG("debug"),
+  CONNECTIVITY_CHECK("connectivitycheck");
 
   private static final String PREFIX = "wtf.emulator";
 
@@ -20,5 +23,11 @@ public enum EwProperties {
       return defaultValue;
     }
     return Boolean.parseBoolean(value);
+  }
+
+  public Provider<Boolean> getFlagProvider(Project project, boolean defaultValue) {
+    return project.getProviders().gradleProperty(PREFIX + "." + propName)
+        .map(Boolean::parseBoolean)
+        .orElse(defaultValue);
   }
 }

--- a/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCollectResultsWorkParameters.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCollectResultsWorkParameters.java
@@ -19,6 +19,8 @@ public interface EwCollectResultsWorkParameters extends WorkParameters  {
 
   ListProperty<OutputType> getOutputs();
 
+  Property<Boolean> getDebug();
+
   Property<Boolean> getPrintOutput();
 
   Property<String> getProxyHost();

--- a/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwConnectivityCheckWorkAction.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwConnectivityCheckWorkAction.java
@@ -1,0 +1,23 @@
+package wtf.emulator.exec;
+
+import org.gradle.api.file.FileSystemOperations;
+import org.gradle.process.ExecOperations;
+import org.gradle.workers.WorkAction;
+import wtf.emulator.EwJson;
+
+import javax.inject.Inject;
+
+public abstract class EwConnectivityCheckWorkAction implements WorkAction<EwConnectivityCheckWorkParameters> {
+  @Inject
+  public abstract ExecOperations getExecOperations();
+
+  @Inject
+  public abstract FileSystemOperations getFileSystemOperations();
+
+  @Override
+  public void execute() {
+    EwConnectivityCheckWorkParameters parameters = getParameters();
+    EwCliExecutor cliExecutor = new EwCliExecutor(EwJson.gson, getExecOperations());
+    cliExecutor.connectivityCheck(parameters);
+  }
+}

--- a/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwConnectivityCheckWorkParameters.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwConnectivityCheckWorkParameters.java
@@ -1,0 +1,39 @@
+package wtf.emulator.exec;
+
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.workers.WorkParameters;
+import wtf.emulator.DnsOverride;
+
+import java.io.File;
+
+public interface EwConnectivityCheckWorkParameters extends WorkParameters {
+  SetProperty<File> getClasspath();
+
+  Property<String> getToken();
+
+  Property<String> getProxyHost();
+
+  Property<Integer> getProxyPort();
+
+  Property<String> getProxyUser();
+
+  Property<String> getProxyPassword();
+
+  ListProperty<String> getDnsServers();
+
+  ListProperty<DnsOverride> getDnsOverrides();
+
+  Property<Boolean> getEgressTunnel();
+
+  Property<String> getEgressLocalhostForwardIp();
+
+  ListProperty<String> getRelays();
+
+  Property<Boolean> getDebug();
+
+  Property<Boolean> getVerbose();
+
+  Property<Boolean> getPrintOutput();
+}

--- a/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwWorkParameters.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwWorkParameters.java
@@ -37,5 +37,7 @@ public interface EwWorkParameters extends EwInvokeConfiguration, WorkParameters 
 
   RegularFileProperty getOutputFile();
 
+  Property<Boolean> getDebug();
+
   Property<String> getTaskPath();
 }

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProjectConfigurator.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProjectConfigurator.java
@@ -75,6 +75,10 @@ public class ProjectConfigurator {
     taskConfigurator.configureRootTask();
     variantConfigurator.configureVariants();
 
+    if (EwProperties.CONNECTIVITY_CHECK.getFlag(target, true)) {
+      taskConfigurator.configureConnectivityCheckTask();
+    }
+
     registerGmdDeviceType();
     registerManagedDeviceExtension();
   }


### PR DESCRIPTION
Adds two new project props:

- `wtf.emulator.debug` to enable debug logging
- `wtf.emulator.connectivitycheck` to register a `emulatorWtfConnectivityCheck` in all the modules where the plugin is applied

The connectivity check task uses the values configured in the `emulatorwtf {}` DSL to run a small set of connectivity checks to emulator.wtf APIs and relay servers. No JSON output mode yet, so not fully ready for release notes either.

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
