### PR TITLE
fix: DeviceSpec.GpuMode deserialization crash

### DIFF
--- a/gradle-plugin-api/src/main/java/wtf/emulator/GpuMode.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/GpuMode.java
@@ -1,17 +1,21 @@
 package wtf.emulator;
 
+import com.google.gson.annotations.SerializedName;
+
 public enum GpuMode {
   /**
    * Use software rendering. Use this if you need deterministic pixel-perfect rendering, e.g. for
    * screenshot testing.
    */
+  @SerializedName("software")
   SOFTWARE("software"),
 
   /**
-   * Use hardware rendering if available. Typically this is available, but there may
+   * Use hardware rendering if available. Typically, this is available, but there may
    * be rare cases where no machines with GPU acceleration are available in our workload cluster.
    * In such cases, the emulator may still use software rendering.
    */
+  @SerializedName("auto")
   AUTO("auto");
 
   private final String cliValue;

--- a/gradle-plugin-core/src/main/java/wtf/emulator/data/DeviceSpec.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/data/DeviceSpec.java
@@ -5,12 +5,9 @@ import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import wtf.emulator.GpuMode;
 
-import javax.annotation.Nullable;
-
 @AutoValue public abstract class DeviceSpec {
   public abstract String model();
   public abstract int api();
-  @Nullable
   public abstract GpuMode gpuMode();
 
   public static Builder builder() {
@@ -21,7 +18,7 @@ import javax.annotation.Nullable;
   public abstract static class Builder {
     public abstract Builder model(String model);
     public abstract Builder api(int api);
-    public abstract Builder gpuMode(@Nullable GpuMode gpuMode);
+    public abstract Builder gpuMode(GpuMode gpuMode);
     public abstract DeviceSpec build();
   }
 


### PR DESCRIPTION
Fixes a nullpointer when trying to deserialize a `RunResultsSummary.TestFailure.DeviceSpec` instance with a null gpuMode.

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [x] I have updated the release notes in `changelog.yaml`
