### PR TITLE
chore: cooldown for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
   schedule:
     interval: "daily"
     time: "16:00"
+  cooldown:
+    default-days: 7
   ignore:
   # never bump gradle-api, we depend on specific versions for backwards-compat
   - dependency-name: "dev.gradleplugins:gradle-api"
@@ -15,3 +17,5 @@ updates:
   schedule:
     interval: "daily"
     time: "16:00"
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
No need to live on the bleeding edge

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
