### PR TITLE
chore: replace all System.getenv usage with Project.providers.environmentVariable

### DIFF
--- a/gradle-plugin-core/src/main/java/wtf/emulator/gmd/EwDeviceTestRunConfigureAction.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/gmd/EwDeviceTestRunConfigureAction.java
@@ -45,8 +45,7 @@ public abstract class EwDeviceTestRunConfigureAction implements DeviceTestRunCon
     EwExtension ext = getProject().getExtensions().getByType(EwExtension.class);
     EwExtensionInternal extInternal = new EwExtensionInternal(ext);
 
-    deviceTestRunInput.getToken().set(ext.getToken().orElse(getProject().provider(() ->
-      System.getenv("EW_API_TOKEN"))));
+    deviceTestRunInput.getToken().set(ext.getToken().orElse(getProject().getProviders().environmentVariable("EW_API_TOKEN")));
     deviceTestRunInput.getToken().disallowChanges();
 
     deviceTestRunInput.getWorkingDir().set(getProject().getRootDir());

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
@@ -96,8 +96,7 @@ public class TaskConfigurator {
 
       task.getClasspath().set(toolConfig);
 
-      task.getToken().set(ext.getToken().orElse(target.provider(() ->
-          System.getenv("EW_API_TOKEN"))));
+      task.getToken().set(ext.getToken().orElse(target.getProviders().environmentVariable("EW_API_TOKEN")));
 
       task.getProxyHost().set(ext.getProxyHost());
       task.getProxyPort().set(ext.getProxyPort());
@@ -187,8 +186,7 @@ public class TaskConfigurator {
 
     task.getClasspath().set(toolConfig);
 
-    task.getToken().set(ext.getToken().orElse(target.provider(() ->
-        System.getenv("EW_API_TOKEN"))));
+    task.getToken().set(ext.getToken().orElse(target.getProviders().environmentVariable("EW_API_TOKEN")));
 
     // don't configure outputs in async mode
     if (!task.getAsync().getOrElse(false)) {


### PR DESCRIPTION
Improves configuration cache usage when `wtf.emulator.gradle` plugin is applied.

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
