### PR TITLE
chore: replace all System.getProperty usage with Project.providers.systemProperty

### DIFF
--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProjectConfigurator.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProjectConfigurator.java
@@ -202,12 +202,12 @@ public class ProjectConfigurator {
     ext.getBaseOutputDir().convention(target.getLayout().getBuildDirectory().dir("test-results"));
     ext.getRepositoryCheckEnabled().convention(true);
 
-    sysPropConvention(ext.getProxyHost(), "https.proxyHost", "http.proxyHost");
-    sysPropConvention(ext.getProxyPort(), Arrays.asList("https.proxyPort", "http.proxyPort"), Integer::parseInt);
-    sysPropConvention(ext.getProxyUser(), "https.proxyUser", "http.proxyUser");
-    sysPropConvention(ext.getProxyPassword(), "https.proxyPassword", "http.proxyPassword");
+    sysPropConvention(target, ext.getProxyHost(), "https.proxyHost", "http.proxyHost");
+    sysPropConvention(target, ext.getProxyPort(), Arrays.asList("https.proxyPort", "http.proxyPort"), Integer::parseInt);
+    sysPropConvention(target, ext.getProxyUser(), "https.proxyUser", "http.proxyUser");
+    sysPropConvention(target, ext.getProxyPassword(), "https.proxyPassword", "http.proxyPassword");
 
-    nonProxyHostsConvention(ext.getNonProxyHosts());
+    nonProxyHostsConvention(target, ext.getNonProxyHosts());
   }
 
   private void configureRuntimeDependency() {

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProviderUtils.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProviderUtils.java
@@ -13,10 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Stream;
-
-import static java.util.function.Function.identity;
 
 public class ProviderUtils {
   public static Provider<Map<String, String>> deviceToCliMap(ProviderFactory providers, EwDeviceSpec device) {

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProviderUtils.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProviderUtils.java
@@ -1,6 +1,7 @@
 package wtf.emulator.setup;
 
 import org.gradle.api.Project;
+import org.gradle.api.Transformer;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -57,16 +58,16 @@ public class ProviderUtils {
    * step.
    */
   public static void sysPropConvention(Project project, Property<String> extProp, String... keys) {
-    sysPropConvention(project, extProp, Arrays.asList(keys), identity());
+    sysPropConvention(project, extProp, Arrays.asList(keys), (s) -> s);
   }
 
   /**
    * Initializes the given {@param extProp} with one of the System properties defined by {@param keys},
    * with decreasing priority, i.e. the first non-blank System property value is used.
    */
-  public static <T> void sysPropConvention(Project project, Property<T> extProp, List<String> keys, Function<String, T> transform) {
+  public static <T> void sysPropConvention(Project project, Property<T> extProp, List<String> keys, Transformer<T, String> transform) {
     final var providers = keys.stream().map(key -> project.getProviders().systemProperty(key));
     final var conventionProvider = providers.reduce(Provider::orElse);
-    conventionProvider.ifPresent(stringProvider -> extProp.convention(stringProvider.map(transform::apply)));
+    conventionProvider.ifPresent(stringProvider -> extProp.convention(stringProvider.map(transform)));
   }
 }

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProviderUtils.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProviderUtils.java
@@ -1,5 +1,6 @@
 package wtf.emulator.setup;
 
+import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -55,29 +56,17 @@ public class ProviderUtils {
    * Variant of {@code sysPropConvention} that directly operates with Strings without an intermediate transform
    * step.
    */
-  public static void sysPropConvention(Property<String> extProp, String... keys) {
-    sysPropConvention(extProp, Arrays.asList(keys), identity());
+  public static void sysPropConvention(Project project, Property<String> extProp, String... keys) {
+    sysPropConvention(project, extProp, Arrays.asList(keys), identity());
   }
 
   /**
    * Initializes the given {@param extProp} with one of the System properties defined by {@param keys},
    * with decreasing priority, i.e. the first non-blank System property value is used.
    */
-  public static <T> void sysPropConvention(Property<T> extProp, List<String> keys, Function<String, T> transform) {
-    for (String key : keys) {
-      String sysPropValue = System.getProperty(key);
-      if (sysPropValue != null && !sysPropValue.isBlank()) {
-        try {
-          T transformed = transform.apply(sysPropValue);
-          if (transformed != null) {
-            extProp.convention(transformed);
-            return;
-          }
-        }
-        catch (Exception e) {
-          // ignore transform failures, e.g. failing to parse an int
-        }
-      }
-    }
+  public static <T> void sysPropConvention(Project project, Property<T> extProp, List<String> keys, Function<String, T> transform) {
+    final var providers = keys.stream().map(key -> project.getProviders().systemProperty(key));
+    final var conventionProvider = providers.reduce(Provider::orElse);
+    conventionProvider.ifPresent(stringProvider -> extProp.convention(stringProvider.map(transform::apply)));
   }
 }

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProviderUtils.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProviderUtils.java
@@ -62,8 +62,15 @@ public class ProviderUtils {
   }
 
   /**
-   * Initializes the given {@param extProp} with one of the System properties defined by {@param keys},
-   * with decreasing priority, i.e. the first non-blank System property value is used.
+   * Initializes the given property from one of the System properties identified by {@code keys}, in
+   * decreasing priority order. The first present System property provider is used; if that property is
+   * present with a blank value, fallback to later keys does not occur.
+   *
+   * @param project the project used to access Gradle providers
+   * @param extProp the property to initialize
+   * @param keys the System property keys to check, in priority order
+   * @param transform transforms the selected System property value before assigning it
+   * @param <T> the target property type
    */
   public static <T> void sysPropConvention(Project project, Property<T> extProp, List<String> keys, Transformer<T, String> transform) {
     final var providers = keys.stream().map(key -> project.getProviders().systemProperty(key));

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProxyUtils.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProxyUtils.java
@@ -20,7 +20,7 @@ public class ProxyUtils {
    */
   public static void nonProxyHostsConvention(Project project, ListProperty<String> property) {
     final var sysPropProvider = project.getProviders().systemProperty("http.nonProxyHosts");
-    property.convention(sysPropProvider.map(sysPropValue -> {))
+    property.convention(sysPropProvider.map(sysPropValue -> {
       if (sysPropValue.isBlank()) {
         return List.of();
       }

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProxyUtils.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/ProxyUtils.java
@@ -1,5 +1,6 @@
 package wtf.emulator.setup;
 
+import org.gradle.api.Project;
 import org.gradle.api.provider.ListProperty;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,24 +11,24 @@ import java.util.List;
 import java.util.Set;
 
 public class ProxyUtils {
+  // drop the localhost and loopback entries as they are not relevant for no_proxy
+  private static final Set<String> IGNORED_HOSTS = new HashSet<>(Arrays.asList("localhost", "127.*", "[::1]"));
+
   /**
    * Initializes the given {@param property} with a list of domains in the `no_proxy` format as a convention,
    * based on the `http.nonProxyHosts` system property.
    */
-  public static void nonProxyHostsConvention(ListProperty<String> property) {
-    String sysPropValue = System.getProperty("http.nonProxyHosts");
-    if (sysPropValue != null && !sysPropValue.isBlank()) {
-      // drop the localhost and loopback entries as they are not relevant for no_proxy
-      Set<String> ignoredHosts = new HashSet<>(Arrays.asList("localhost", "127.*", "[::1]"));
+  public static void nonProxyHostsConvention(Project project, ListProperty<String> property) {
+    final var sysPropProvider = project.getProviders().systemProperty("http.nonProxyHosts");
+    property.convention(sysPropProvider.map(sysPropValue -> {))
+      if (sysPropValue.isBlank()) {
+        return List.of();
+      }
 
       // Java's http.nonProxyHosts uses '|' as a separator and allows '*' wildcards
       String[] parts = sysPropValue.split("\\|");
-      List<String> values = mapNonProxyHosts(parts, ignoredHosts);
-
-      if (!values.isEmpty()) {
-        property.convention(values);
-      }
-    }
+      return mapNonProxyHosts(parts);
+    }));
   }
 
   /**
@@ -35,14 +36,14 @@ public class ProxyUtils {
    * NOTE: This does not cover all edge cases, just the common ones. For instance, wildcards
    * in the middle of a hostname are not supported in no_proxy and thus ignored.
    */
-  private static @NotNull List<String> mapNonProxyHosts(String[] parts, Set<String> ignoredHosts) {
+  private static @NotNull List<String> mapNonProxyHosts(String[] parts) {
     List<String> values = new ArrayList<>(parts.length);
     for (String part : parts) {
       String t = part.trim();
       if (t.isEmpty()) continue;
 
       // ignore the default loopback entries
-      if (ignoredHosts.contains(t)) {
+      if (ProxyUtils.IGNORED_HOSTS.contains(t)) {
         continue;
       }
 


### PR DESCRIPTION
Improves configuration cache usage when `wtf.emulator.gradle` plugin is applied.

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
