### PR TITLE
chore: bump default ew-cli version to 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ import wtf.emulator.TestReporter
 import java.time.Duration
 
 emulatorwtf {
-    // CLI version to use, defaults to 1.2.0
-    version.set("1.2.0")
+    // CLI version to use, defaults to 1.2.2
+    version.set("1.2.2")
 
     // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
     // instead of this or passing this value in via a project property
@@ -404,8 +404,8 @@ import wtf.emulator.TestReporter
 import java.time.Duration
 
 emulatorwtf {
-    // CLI version to use, defaults to 1.2.0
-    version = '1.2.0'
+    // CLI version to use, defaults to 1.2.2
+    version = '1.2.2'
 
     // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
     // instead of this or passing this value in via a project property

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -7,3 +7,4 @@
 unreleased:
 - "Fixed: plugin no longer fails to apply on Kotlin Multiplatform projects with AGP 9 where `withDeviceTest {}` is declared after the `plugins {}` block."
 - "New: added support for `com.android.kotlin.multiplatform.library` plugin (AGP 9 KMP Android library), automatically creating `testAndroidMainWithEmulatorWtf` and related tasks."
+- "Maintenance: bumped default `ew-cli` version to 1.2.2."

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ autovalue-gson-runtime = { module = "com.ryanharter.auto.value:auto-value-gson-r
 autovalue-gson-extension = { module = "com.ryanharter.auto.value:auto-value-gson-extension", version.ref = "autovalue-gson" }
 autovalue-gson-factory = { module = "com.ryanharter.auto.value:auto-value-gson-factory", version.ref = "autovalue-gson" }
 
-emulatorwtf-cli = "wtf.emulator:ew-cli:1.2.0"
+emulatorwtf-cli = "wtf.emulator:ew-cli:1.2.2"
 emulatorwtf-runtime = "wtf.emulator:test-runtime-android:0.2.1"
 
 [bundles]


### PR DESCRIPTION


---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [x] I have updated the release notes in `changelog.yaml`
