### PR TITLE
chore: switch from the deprecated gradle/wrapper-validation-action to gradle/actions/wrapper-validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
         mkdir -p $HOME/.asdf/installs/
         ln -s $HOME/.local/share/mise/installs/java $HOME/.asdf/installs/
     - name: Validate Gradle wrapper
-      uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      uses: gradle/actions/wrapper-validation@v6
     - name: Setup Gradle Cache
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
https://github.com/gradle/wrapper-validation-action -> 
As of v3 this action has been superceded by `gradle/actions/wrapper-validation`. Any workflow that uses `gradle/wrapper-validation-action@v3` will transparently delegate to `gradle/actions/wrapper-validation@v3.`

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
