### PR TITLE
chore: bump default ew-cli to 1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ import wtf.emulator.TestReporter
 import java.time.Duration
 
 emulatorwtf {
-    // CLI version to use, defaults to 1.3.0
-    version.set("1.3.0")
+    // CLI version to use, defaults to 1.3.2
+    version.set("1.3.2")
 
     // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
     // instead of this or passing this value in via a project property
@@ -404,8 +404,8 @@ import wtf.emulator.TestReporter
 import java.time.Duration
 
 emulatorwtf {
-    // CLI version to use, defaults to 1.3.0
-    version = '1.3.0'
+    // CLI version to use, defaults to 1.3.2
+    version = '1.3.2'
 
     // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
     // instead of this or passing this value in via a project property

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -6,3 +6,6 @@
 # (Markdown is supported and encouraged)
 unreleased:
 - "Fixed: the emulator.wtf Gradle plugin crashed when using the Gradle Test Reporting API on Gradle 9.4.0 and later."
+- "Fixed: slow or stalled file uploads would not time out correctly, causing test runs to hang."
+- "Fixed: corner-case connectivity issue where test runs could stall for minutes before running any tests."
+- "Maintenance: bumped default `ew-cli` version to 1.3.2."

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ autovalue-gson-runtime = { module = "com.ryanharter.auto.value:auto-value-gson-r
 autovalue-gson-extension = { module = "com.ryanharter.auto.value:auto-value-gson-extension", version.ref = "autovalue-gson" }
 autovalue-gson-factory = { module = "com.ryanharter.auto.value:auto-value-gson-factory", version.ref = "autovalue-gson" }
 
-emulatorwtf-cli = "wtf.emulator:ew-cli:1.3.0"
+emulatorwtf-cli = "wtf.emulator:ew-cli:1.3.2"
 emulatorwtf-runtime = "wtf.emulator:test-runtime-android:0.2.1"
 
 [bundles]


### PR DESCRIPTION
Bump default `ew-cli` to 1.3.2 to get the upload path resiliency improvements.

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [x] I have updated the release notes in `changelog.yaml`
