### PR TITLE
chore: bump ew-cli to 1.4.0

### DIFF
--- a/changelog.yaml
+++ b/changelog.yaml
@@ -5,4 +5,5 @@
 #
 # (Markdown is supported and encouraged)
 unreleased:
-- Bumped default `ew-cli` version to 1.3.3.
+- "Improved: large APK file uploads are now using multiple connections in parallel, making uploads substantially faster."
+- "Maintenance: bumped default `ew-cli` version to 1.4.0."

--- a/gradle-plugin-api/src/main/java/wtf/emulator/EwInvokeConfiguration.java
+++ b/gradle-plugin-api/src/main/java/wtf/emulator/EwInvokeConfiguration.java
@@ -223,4 +223,23 @@ public interface EwInvokeConfiguration extends EwProxyConfiguration {
    * <a href="https://developer.android.com/reference/androidx/test/runner/AndroidJUnitRunner#typical-usage">here</a>.
    */
   Property<String> getTestTargetsString();
+
+  /**
+   * Override the multipart upload chunk size in bytes. Left unset the server-provided (or default)
+   * value is used; useful for debugging / tuning.
+   */
+  Property<Long> getUploadChunkSize();
+
+  /**
+   * Override the number of multipart chunks uploaded concurrently. Left unset the server-provided
+   * (or default) value is used; useful for debugging / tuning.
+   */
+  Property<Integer> getUploadThreadCount();
+
+  /**
+   * Override the base per-chunk upload call timeout in seconds; the effective timeout is this
+   * multiplied by the thread count. Left unset the server-provided (or default) value is used;
+   * useful for debugging / tuning.
+   */
+  Property<Integer> getUploadTimeoutBaseSeconds();
 }

--- a/gradle-plugin-core/src/main/java/wtf/emulator/DslInternals.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/DslInternals.java
@@ -58,6 +58,9 @@ public class DslInternals {
     config.getIgnoreFailures().convention(defaults.getIgnoreFailures());
     config.getAsync().convention(defaults.getAsync());
     config.getPrintOutput().convention(defaults.getPrintOutput());
+    config.getUploadChunkSize().convention(defaults.getUploadChunkSize());
+    config.getUploadThreadCount().convention(defaults.getUploadThreadCount());
+    config.getUploadTimeoutBaseSeconds().convention(defaults.getUploadTimeoutBaseSeconds());
     config.getTestTargetsString().convention(
       // first targets from this config
       config.getTestTargets().map(TargetUtils::toCliString)

--- a/gradle-plugin-core/src/main/java/wtf/emulator/EwExecTask.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/EwExecTask.java
@@ -253,6 +253,18 @@ public abstract class EwExecTask extends DefaultTask {
 
   @Optional
   @Input
+  public abstract Property<Long> getUploadChunkSize();
+
+  @Optional
+  @Input
+  public abstract Property<Integer> getUploadThreadCount();
+
+  @Optional
+  @Input
+  public abstract Property<Integer> getUploadTimeoutBaseSeconds();
+
+  @Optional
+  @Input
   public abstract Property<String> getProxyHost();
 
   @Optional
@@ -332,6 +344,9 @@ public abstract class EwExecTask extends DefaultTask {
     p.getPrintOutput().set(getPrintOutput());
     p.getDebug().set(getDebug());
     p.getTestTargetsString().set(getTestTargetsString());
+    p.getUploadChunkSize().set(getUploadChunkSize());
+    p.getUploadThreadCount().set(getUploadThreadCount());
+    p.getUploadTimeoutBaseSeconds().set(getUploadTimeoutBaseSeconds());
     p.getProxyHost().set(getProxyHost());
     p.getProxyPort().set(getProxyPort());
     p.getProxyUser().set(getProxyUser());

--- a/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCliExecutor.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/exec/EwCliExecutor.java
@@ -425,6 +425,18 @@ public class EwCliExecutor {
       spec.args("--file-cache-ttl", toCliString(parameters.getFileCacheTtl().get()));
     }
 
+    if (parameters.getUploadChunkSize().isPresent()) {
+      spec.args("--upload-chunk-size", parameters.getUploadChunkSize().get().toString());
+    }
+
+    if (parameters.getUploadThreadCount().isPresent()) {
+      spec.args("--upload-thread-count", parameters.getUploadThreadCount().get().toString());
+    }
+
+    if (parameters.getUploadTimeoutBaseSeconds().isPresent()) {
+      spec.args("--upload-timeout-base-seconds", parameters.getUploadTimeoutBaseSeconds().get().toString());
+    }
+
     if (parameters.getTestCacheEnabled().isPresent()) {
       if (parameters.getTestCacheEnabled().get()) {
         spec.args("--test-cache");

--- a/gradle-plugin-core/src/main/java/wtf/emulator/gmd/EwDeviceTestRunConfigureAction.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/gmd/EwDeviceTestRunConfigureAction.java
@@ -162,6 +162,15 @@ public abstract class EwDeviceTestRunConfigureAction implements DeviceTestRunCon
     deviceTestRunInput.getTestTargetsString().set(ext.getTestTargetsString());
     deviceTestRunInput.getTestTargetsString().disallowChanges();
 
+    deviceTestRunInput.getUploadChunkSize().set(ext.getUploadChunkSize());
+    deviceTestRunInput.getUploadChunkSize().disallowChanges();
+
+    deviceTestRunInput.getUploadThreadCount().set(ext.getUploadThreadCount());
+    deviceTestRunInput.getUploadThreadCount().disallowChanges();
+
+    deviceTestRunInput.getUploadTimeoutBaseSeconds().set(ext.getUploadTimeoutBaseSeconds());
+    deviceTestRunInput.getUploadTimeoutBaseSeconds().disallowChanges();
+
     deviceTestRunInput.getProxyHost().set(ext.getProxyHost());
     deviceTestRunInput.getProxyHost().disallowChanges();
 

--- a/gradle-plugin-core/src/main/java/wtf/emulator/gmd/EwDeviceTestRunInput.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/gmd/EwDeviceTestRunInput.java
@@ -217,6 +217,18 @@ public abstract class EwDeviceTestRunInput implements DeviceTestRunInput {
 
   @Optional
   @Input
+  public abstract Property<Long> getUploadChunkSize();
+
+  @Optional
+  @Input
+  public abstract Property<Integer> getUploadThreadCount();
+
+  @Optional
+  @Input
+  public abstract Property<Integer> getUploadTimeoutBaseSeconds();
+
+  @Optional
+  @Input
   public abstract Property<String> getProxyHost();
 
   @Optional

--- a/gradle-plugin-core/src/main/java/wtf/emulator/gmd/EwDeviceTestRunTaskAction.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/gmd/EwDeviceTestRunTaskAction.java
@@ -183,6 +183,9 @@ public abstract class EwDeviceTestRunTaskAction implements DeviceTestRunTaskActi
     workParams.getAsync().set(testRunInput.getAsync());
     workParams.getPrintOutput().set(testRunInput.getPrintOutput());
     workParams.getTestTargetsString().set(testRunInput.getTestTargetsString());
+    workParams.getUploadChunkSize().set(testRunInput.getUploadChunkSize());
+    workParams.getUploadThreadCount().set(testRunInput.getUploadThreadCount());
+    workParams.getUploadTimeoutBaseSeconds().set(testRunInput.getUploadTimeoutBaseSeconds());
     workParams.getProxyHost().set(testRunInput.getProxyHost());
     workParams.getProxyPort().set(testRunInput.getProxyPort());
     workParams.getProxyUser().set(testRunInput.getProxyUser());

--- a/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
+++ b/gradle-plugin-core/src/main/java/wtf/emulator/setup/TaskConfigurator.java
@@ -290,6 +290,10 @@ public class TaskConfigurator {
 
     task.getTestTargetsString().set(config.getTestTargetsString());
 
+    task.getUploadChunkSize().set(config.getUploadChunkSize());
+    task.getUploadThreadCount().set(config.getUploadThreadCount());
+    task.getUploadTimeoutBaseSeconds().set(config.getUploadTimeoutBaseSeconds());
+
     task.getProxyHost().set(config.getProxyHost());
     task.getProxyPort().set(config.getProxyPort());
     task.getProxyUser().set(config.getProxyUser());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ autovalue-gson-runtime = { module = "com.ryanharter.auto.value:auto-value-gson-r
 autovalue-gson-extension = { module = "com.ryanharter.auto.value:auto-value-gson-extension", version.ref = "autovalue-gson" }
 autovalue-gson-factory = { module = "com.ryanharter.auto.value:auto-value-gson-factory", version.ref = "autovalue-gson" }
 
-emulatorwtf-cli = "wtf.emulator:ew-cli:1.3.3"
+emulatorwtf-cli = "wtf.emulator:ew-cli:1.4.0"
 emulatorwtf-runtime = "wtf.emulator:test-runtime-android:0.2.1"
 
 [bundles]


### PR DESCRIPTION
Bump `ew-cli` to 1.4.0 to get better upload performance.
Also exposes upload tunables without adding them to the `README.md` as they're more on the side of internals.

NOTE: `ew-cli` 1.4.0 itself not shipped yet so the build will fail initially.

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [x] I have updated the release notes in `changelog.yaml`
