### PR TITLE
build: use JDK25 for building

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-java = 'zulu-17.40.19'
+java = 'zulu-25.36.15.0'


### PR DESCRIPTION
Switches to JDK25 for building.
The emitted classes and the toolchain are still JDK17.

---

<!-- release-notes -->
**Release notes:**
- [x] None of the changes require release notes
- [ ] I have updated the release notes in `changelog.yaml`
