### PR TITLE
chore: bump ew-cli to 1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ import wtf.emulator.TestReporter
 import java.time.Duration
 
 emulatorwtf {
-    // CLI version to use, defaults to 1.4.1
-    version.set("1.4.1")
+    // CLI version to use, defaults to 1.4.2
+    version.set("1.4.2")
 
     // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
     // instead of this or passing this value in via a project property
@@ -404,8 +404,8 @@ import wtf.emulator.TestReporter
 import java.time.Duration
 
 emulatorwtf {
-    // CLI version to use, defaults to 1.4.1
-    version = '1.4.1'
+    // CLI version to use, defaults to 1.4.2
+    version = '1.4.2'
 
     // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
     // instead of this or passing this value in via a project property

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -5,10 +5,5 @@
 #
 # (Markdown is supported and encouraged)
 unreleased:
-- |
-  New **(enterprise customers only)**: the emulator binary and system images are now loosely pinned to the emulator.wtf Gradle Plugin version.
-  CI pipelines that randomly start to fail because we've made an emulator binary update is a bad day for everyone - you can
-  now control when you get the updates by updating the emulator.wtf Gradle Plugin in a timely manner.
-  NOTE: we won't be keeping old combinations available forever, if you stay on a relatively old version of the Gradle plugin you
-  will get a silent update.
-- "Maintenance: bumped default `ew-cli` version to 1.4.1."
+- "Improved: we increased the maximum APK size to 1GiB."
+- "Maintenance: bumped default `ew-cli` version to 1.4.2."

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ autovalue-gson-runtime = { module = "com.ryanharter.auto.value:auto-value-gson-r
 autovalue-gson-extension = { module = "com.ryanharter.auto.value:auto-value-gson-extension", version.ref = "autovalue-gson" }
 autovalue-gson-factory = { module = "com.ryanharter.auto.value:auto-value-gson-factory", version.ref = "autovalue-gson" }
 
-emulatorwtf-cli = "wtf.emulator:ew-cli:1.4.1"
+emulatorwtf-cli = "wtf.emulator:ew-cli:1.4.2"
 emulatorwtf-runtime = "wtf.emulator:test-runtime-android:0.2.1"
 
 [bundles]


### PR DESCRIPTION
NOTE: requires `ew-cli` 1.4.2 to be shipped first.

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [x] I have updated the release notes in `changelog.yaml`
