### PR TITLE
chore: bump ew-cli to 1.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ import wtf.emulator.TestReporter
 import java.time.Duration
 
 emulatorwtf {
-    // CLI version to use, defaults to 1.4.2
-    version.set("1.4.2")
+    // CLI version to use, defaults to 1.4.3
+    version.set("1.4.3")
 
     // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
     // instead of this or passing this value in via a project property
@@ -404,8 +404,8 @@ import wtf.emulator.TestReporter
 import java.time.Duration
 
 emulatorwtf {
-    // CLI version to use, defaults to 1.4.2
-    version = '1.4.2'
+    // CLI version to use, defaults to 1.4.3
+    version = '1.4.3'
 
     // emulator.wtf API token, we recommend either using the EW_API_TOKEN env var
     // instead of this or passing this value in via a project property

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -4,4 +4,5 @@
 # - "Made `thingamajig` faster, read more [here](https://example.com)."
 #
 # (Markdown is supported and encouraged)
-unreleased: []
+unreleased:
+- "New (enterprise customers only): ATD emulators now have 4GiB of RAM instead of 2GiB. Customers on the Startup and Scaleup plans get this change immediately without having to upgrade the plugin."

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ autovalue-gson-runtime = { module = "com.ryanharter.auto.value:auto-value-gson-r
 autovalue-gson-extension = { module = "com.ryanharter.auto.value:auto-value-gson-extension", version.ref = "autovalue-gson" }
 autovalue-gson-factory = { module = "com.ryanharter.auto.value:auto-value-gson-factory", version.ref = "autovalue-gson" }
 
-emulatorwtf-cli = "wtf.emulator:ew-cli:1.4.2"
+emulatorwtf-cli = "wtf.emulator:ew-cli:1.4.3"
 emulatorwtf-runtime = "wtf.emulator:test-runtime-android:0.2.1"
 
 [bundles]


### PR DESCRIPTION
Bump `ew-cli` to 1.4.3.

---

<!-- release-notes -->
**Release notes:**
- [ ] None of the changes require release notes
- [x] I have updated the release notes in `changelog.yaml`
